### PR TITLE
Add basic top-level tracing, remove spinoff (WIP)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,13 +58,15 @@ dependencies = [
  "futures",
  "indicatif",
  "lazy_static",
+ "log",
  "num-bigfloat",
  "regex",
  "serde",
  "serde_json",
- "spinoff",
  "thiserror",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "uniswap_v3_math",
 ]
 
@@ -434,17 +436,6 @@ dependencies = [
  "sha2 0.10.7",
  "sha3",
  "thiserror",
-]
-
-[[package]]
-name = "colored"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
-dependencies = [
- "is-terminal",
- "lazy_static",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1723,9 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "md-5"
@@ -1782,6 +1773,16 @@ name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num-bigfloat"
@@ -1887,6 +1888,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1945,12 +1952,6 @@ dependencies = [
  "rand_core",
  "subtle",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "path-slash"
@@ -2722,6 +2723,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2790,17 +2800,6 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spinoff"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee259f96b31e7a18657d11741fe30d63f98e07de70e7a19d2b705ab9b331cdc"
-dependencies = [
- "colored",
- "once_cell",
- "paste",
-]
 
 [[package]]
 name = "spki"
@@ -2949,6 +2948,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.27",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -3131,6 +3140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
+ "valuable",
 ]
 
 [[package]]
@@ -3141,6 +3151,31 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project",
  "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3264,6 +3299,12 @@ dependencies = [
  "getrandom",
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,14 +27,16 @@ serde = "1.0.176"
 num-bigfloat = "1.6.2"
 uniswap_v3_math = "0.4.0"
 regex = "1.9.1"
-spinoff = "0.7.0"
 arraydeque = {version = "0.5.1", optional = true}
 eyre = "0.6.8"
 lazy_static = "1.4.0"
-
+log = "0.4.20"
+tracing = "0.1.37"
 
 [features]
 default = ["filters", "state-space"]
 filters = []
 state-space = ["arraydeque"]
 
+[dev-dependencies]
+tracing-subscriber = "0.3.17"

--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
 # amms-rs [![Github Actions][gha-badge]][gha]
+
 [gha]: https://github.com/darkforestry/amms-rs/actions
 [gha-badge]: https://github.com/darkforestry/amms-rs/actions/workflows/ci.yml/badge.svg
 
-`amms-rs` is a Rust library to interact with automated market makers across EVM chains. 
+`amms-rs` is a Rust library to interact with automated market makers across EVM chains.
 
-
-This lib provides functionality to [discover](https://github.com/darkforestry/amms-rs/blob/main/examples/discover-factories.rs), [sync](https://github.com/darkforestry/amms-rs/blob/main/examples/sync-amms.rs), [filter](https://github.com/darkforestry/amms-rs/blob/main/examples/filter-value.rs), and interact with a variety of AMMs. This library also provides functionality to keep a [state space synced](https://github.com/darkforestry/amms-rs/blob/main/examples/state-space.rs), abstracting logic to handle chain reorgs, maintaining a state change cache and more. 
+This lib provides functionality to [discover](https://github.com/darkforestry/amms-rs/blob/main/examples/discover-factories.rs), [sync](https://github.com/darkforestry/amms-rs/blob/main/examples/sync-amms.rs), [filter](https://github.com/darkforestry/amms-rs/blob/main/examples/filter-value.rs), and interact with a variety of AMMs. This library also provides functionality to keep a [state space synced](https://github.com/darkforestry/amms-rs/blob/main/examples/state-space.rs), abstracting logic to handle chain reorgs, maintaining a state change cache and more.
 
 `amms-rs` was built with modularity in mind, making it quick and easy to add a new `AMM` variant by implementing the `AutomatedMarketMaker` trait. For a full walkthrough on how to quickly implement a new `AMM`, check out [`addingAnAMM.md`](https://github.com/darkforestry/amms-rs/blob/main/docs/addingAnAMM.md).
-
-
 
 ## Installation
 
@@ -21,24 +19,17 @@ amms = "0.6.1"
 ```
 
 ## Tests and Docs are still being written 🏗️.
+
 Tests are still being written, assume bugs until tested. If you would like to help contribute on the tests or docs, feel free to open up an issue or make a PR.
-
-
-
-
 
 ## Supported AMMs
 
-| AMM | Status |
-|----------|------|
-| UniswapV2 Pools | ✅||
-| UniswapV3 Pools | ✅||
-| ERC4626 Vaults | ✅||
-| Izumi Pools | 🟨||
-| Curve Pools | ❌||
-| Balancer Pools | ❌||
-| Bancor Pools | ❌||
-
-
-
-
+| AMM             | Status |
+| --------------- | ------ | --- |
+| UniswapV2 Pools | ✅     |     |
+| UniswapV3 Pools | ✅     |     |
+| ERC4626 Vaults  | ✅     |     |
+| Izumi Pools     | 🟨     |     |
+| Curve Pools     | ❌     |     |
+| Balancer Pools  | ❌     |     |
+| Bancor Pools    | ❌     |     |

--- a/examples/discover-erc-4626-vaults.rs
+++ b/examples/discover-erc-4626-vaults.rs
@@ -4,12 +4,16 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
+    tracing_subscriber::fmt::init();
+
     //Add rpc endpoint here:
     let rpc_endpoint = std::env::var("ETHEREUM_RPC_ENDPOINT")?;
     let provider = Arc::new(Provider::<Http>::try_from(rpc_endpoint)?);
 
     //discover vaults
-    let _vaults = discovery::erc_4626::discover_erc_4626_vaults(provider, 30000).await?;
+    let vaults = discovery::erc_4626::discover_erc_4626_vaults(provider, 30000).await?;
+
+    println!("Vaults: {:?}", vaults);
 
     Ok(())
 }

--- a/examples/discover-factories.rs
+++ b/examples/discover-factories.rs
@@ -4,8 +4,9 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    let rpc_endpoint = std::env::var("ETHEREUM_RPC_ENDPOINT")?;
+    tracing_subscriber::fmt::init();
 
+    let rpc_endpoint = std::env::var("ETHEREUM_RPC_ENDPOINT")?;
     let provider = Arc::new(Provider::<Http>::try_from(rpc_endpoint)?);
 
     // Find all UniswapV2 and UniswapV3 compatible factories and filter out matches with less than 1000 AMMs
@@ -17,7 +18,7 @@ async fn main() -> eyre::Result<()> {
         ],
         number_of_amms_threshold,
         provider,
-        100000,
+        50000,
     )
     .await?;
 

--- a/examples/filter-value.rs
+++ b/examples/filter-value.rs
@@ -14,12 +14,14 @@ use std::{str::FromStr, sync::Arc};
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
+    tracing_subscriber::fmt::init();
+
     let rpc_endpoint = std::env::var("ETHEREUM_RPC_ENDPOINT")?;
     let provider = Arc::new(Provider::<Http>::try_from(rpc_endpoint)?);
 
     // Initialize factories
     let factories = vec![
-        //UniswapV2
+        //Add UniswapV2
         Factory::UniswapV2Factory(UniswapV2Factory::new(
             H160::from_str("0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f")?,
             2638438,

--- a/examples/simulate-swap.rs
+++ b/examples/simulate-swap.rs
@@ -7,6 +7,8 @@ use std::{str::FromStr, sync::Arc};
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
+    tracing_subscriber::fmt::init();
+
     let rpc_endpoint = std::env::var("ETHEREUM_RPC_ENDPOINT")?;
     let middleware = Arc::new(Provider::<Http>::try_from(rpc_endpoint)?);
 

--- a/examples/simulate-swap.rs
+++ b/examples/simulate-swap.rs
@@ -13,11 +13,11 @@ async fn main() -> eyre::Result<()> {
     let middleware = Arc::new(Provider::<Http>::try_from(rpc_endpoint)?);
 
     // Initialize the pool
-    let pool_address = H160::from_str("0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc")?;
+    let pool_address = H160::from_str("0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc")?; // WETH/USDC
     let pool = UniswapV2Pool::new_from_address(pool_address, 300, middleware.clone()).await?;
 
     // Simulate a swap
-    let token_in = H160::from_str("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")?;
+    let token_in = H160::from_str("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")?; // WETH
     let amount_out = pool.simulate_swap(token_in, U256::from(10000))?;
 
     println!("Amount out: {amount_out}");

--- a/examples/state-space.rs
+++ b/examples/state-space.rs
@@ -12,6 +12,8 @@ use std::{str::FromStr, sync::Arc};
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
+    tracing_subscriber::fmt::init();
+
     let rpc_endpoint = std::env::var("ETHEREUM_RPC_ENDPOINT")?;
     let ws_endpoint = std::env::var("ETHEREUM_WS_ENDPOINT")?;
 
@@ -21,7 +23,7 @@ async fn main() -> eyre::Result<()> {
 
     // Initialize factories
     let factories = vec![
-        //UniswapV2
+        //Add UniswapV2
         Factory::UniswapV2Factory(UniswapV2Factory::new(
             H160::from_str("0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f")?,
             2638438,

--- a/examples/swap-calldata.rs
+++ b/examples/swap-calldata.rs
@@ -7,6 +7,8 @@ use std::{str::FromStr, sync::Arc};
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
+    tracing_subscriber::fmt::init();
+
     let rpc_endpoint = std::env::var("ETHEREUM_RPC_ENDPOINT")?;
     let middleware = Arc::new(Provider::<Http>::try_from(rpc_endpoint)?);
 

--- a/examples/sync-amms.rs
+++ b/examples/sync-amms.rs
@@ -13,18 +13,20 @@ use std::{str::FromStr, sync::Arc};
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
+    tracing_subscriber::fmt::init();
+
     //Add rpc endpoint here:
     let rpc_endpoint = std::env::var("ETHEREUM_RPC_ENDPOINT")?;
     let provider = Arc::new(Provider::<Http>::try_from(rpc_endpoint)?);
 
     let factories = vec![
-        //UniswapV2
+        //Add UniswapV2
         Factory::UniswapV2Factory(UniswapV2Factory::new(
             H160::from_str("0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f")?,
             2638438,
             300,
         )),
-        // //Add Sushiswap
+        //Add Sushiswap
         Factory::UniswapV2Factory(UniswapV2Factory::new(
             H160::from_str("0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac")?,
             10794229,
@@ -38,7 +40,7 @@ async fn main() -> eyre::Result<()> {
     ];
 
     //Sync pairs
-    sync::sync_amms(factories, provider, None, 1000).await?;
+    sync::sync_amms(factories, provider, None, 500).await?;
 
     Ok(())
 }

--- a/src/amm/uniswap_v2/batch_request/mod.rs
+++ b/src/amm/uniswap_v2/batch_request/mod.rs
@@ -142,6 +142,7 @@ pub async fn get_v2_pool_data_batch_request<M: Middleware>(
     pool: &mut UniswapV2Pool,
     middleware: Arc<M>,
 ) -> Result<(), AMMError<M>> {
+    tracing::info!(?pool.address, "getting pool data");
     let constructor_args = Token::Tuple(vec![Token::Array(vec![Token::Address(pool.address)])]);
 
     let deployer = IGetUniswapV2PoolDataBatchRequest::deploy(middleware.clone(), constructor_args)?;

--- a/src/amm/uniswap_v2/batch_request/mod.rs
+++ b/src/amm/uniswap_v2/batch_request/mod.rs
@@ -43,7 +43,7 @@ pub async fn get_pairs_batch_request<M: Middleware>(
     step: U256,
     middleware: Arc<M>,
 ) -> Result<Vec<H160>, AMMError<M>> {
-    tracing::trace!("getting pairs {}-{}", from, step);
+    tracing::info!("getting pairs {}-{}", from, step);
 
     let mut pairs = vec![];
 
@@ -80,6 +80,8 @@ pub async fn get_amm_data_batch_request<M: Middleware>(
     amms: &mut [AMM],
     middleware: Arc<M>,
 ) -> Result<(), AMMError<M>> {
+    tracing::info!("getting data for {} AMMs", amms.len());
+
     let mut target_addresses = vec![];
     for amm in amms.iter() {
         target_addresses.push(Token::Address(amm.address()));
@@ -120,6 +122,7 @@ pub async fn get_amm_data_batch_request<M: Middleware>(
                                     uniswap_v2_pool.to_owned(),
                                     pool_data,
                                 ) {
+                                    tracing::trace!(?pool);
                                     *uniswap_v2_pool = pool;
                                 }
                             }
@@ -139,8 +142,6 @@ pub async fn get_v2_pool_data_batch_request<M: Middleware>(
     pool: &mut UniswapV2Pool,
     middleware: Arc<M>,
 ) -> Result<(), AMMError<M>> {
-    // tracing::trace!();
-
     let constructor_args = Token::Tuple(vec![Token::Array(vec![Token::Address(pool.address)])]);
 
     let deployer = IGetUniswapV2PoolDataBatchRequest::deploy(middleware.clone(), constructor_args)?;

--- a/src/amm/uniswap_v2/batch_request/mod.rs
+++ b/src/amm/uniswap_v2/batch_request/mod.rs
@@ -43,6 +43,8 @@ pub async fn get_pairs_batch_request<M: Middleware>(
     step: U256,
     middleware: Arc<M>,
 ) -> Result<Vec<H160>, AMMError<M>> {
+    tracing::trace!("getting pairs {}-{}", from, step);
+
     let mut pairs = vec![];
 
     let constructor_args = Token::Tuple(vec![
@@ -137,6 +139,8 @@ pub async fn get_v2_pool_data_batch_request<M: Middleware>(
     pool: &mut UniswapV2Pool,
     middleware: Arc<M>,
 ) -> Result<(), AMMError<M>> {
+    // tracing::trace!();
+
     let constructor_args = Token::Tuple(vec![Token::Array(vec![Token::Address(pool.address)])]);
 
     let deployer = IGetUniswapV2PoolDataBatchRequest::deploy(middleware.clone(), constructor_args)?;

--- a/src/amm/uniswap_v2/factory.rs
+++ b/src/amm/uniswap_v2/factory.rs
@@ -59,6 +59,8 @@ impl UniswapV2Factory {
 
         let pairs_length: U256 = factory.all_pairs_length().call().await?;
 
+        tracing::trace!("getting all {} pairs of factory {}", pairs_length, self.address);
+
         let mut pairs = vec![];
         let step = 766; //max batch size for this call until codesize is too large
         let mut idx_from = U256::zero();

--- a/src/amm/uniswap_v2/factory.rs
+++ b/src/amm/uniswap_v2/factory.rs
@@ -59,7 +59,7 @@ impl UniswapV2Factory {
 
         let pairs_length: U256 = factory.all_pairs_length().call().await?;
 
-        tracing::trace!("getting all {} pairs of factory {}", pairs_length, self.address);
+        tracing::trace!(?pairs_length, factory = ?self.address, "getting all pairs of factory via batched calls");
 
         let mut pairs = vec![];
         let step = 766; //max batch size for this call until codesize is too large

--- a/src/amm/uniswap_v2/mod.rs
+++ b/src/amm/uniswap_v2/mod.rs
@@ -107,6 +107,8 @@ impl AutomatedMarketMaker for UniswapV2Pool {
     }
 
     fn simulate_swap(&self, token_in: H160, amount_in: U256) -> Result<U256, SwapSimulationError> {
+        tracing::info!(?token_in, ?amount_in, "simulating swap");
+
         if self.token_a == token_in {
             Ok(self.get_amount_out(
                 amount_in,
@@ -127,6 +129,8 @@ impl AutomatedMarketMaker for UniswapV2Pool {
         token_in: H160,
         amount_in: U256,
     ) -> Result<U256, SwapSimulationError> {
+        tracing::info!(?token_in, ?amount_in, "simulating swap");
+
         if self.token_a == token_in {
             let amount_out = self.get_amount_out(
                 amount_in,
@@ -134,8 +138,13 @@ impl AutomatedMarketMaker for UniswapV2Pool {
                 U256::from(self.reserve_1),
             );
 
+            tracing::trace!(?amount_out);
+            tracing::trace!(?self.reserve_0, ?self.reserve_1, "pool reserves before");
+
             self.reserve_0 += amount_in.as_u128();
             self.reserve_1 -= amount_out.as_u128();
+
+            tracing::trace!(?self.reserve_0, ?self.reserve_1, "pool reserves after");
 
             Ok(amount_out)
         } else {
@@ -145,8 +154,13 @@ impl AutomatedMarketMaker for UniswapV2Pool {
                 U256::from(self.reserve_0),
             );
 
+            tracing::trace!(?amount_out);
+            tracing::trace!(?self.reserve_0, ?self.reserve_1, "pool reserves before");
+
             self.reserve_0 -= amount_out.as_u128();
             self.reserve_1 += amount_in.as_u128();
+
+            tracing::trace!(?self.reserve_0, ?self.reserve_1, "pool reserves after");
 
             Ok(amount_out)
         }
@@ -262,6 +276,7 @@ impl UniswapV2Pool {
         middleware: Arc<M>,
     ) -> Result<(u128, u128), AMMError<M>> {
         tracing::trace!("getting reserves of {}", self.address);
+
         //Initialize a new instance of the Pool
         let v2_pair = IUniswapV2Pair::new(self.address, middleware);
         // Make a call to get the reserves
@@ -269,6 +284,7 @@ impl UniswapV2Pool {
             Ok(result) => result,
             Err(contract_error) => return Err(AMMError::ContractError(contract_error)),
         };
+
         tracing::trace!(reserve_0, reserve_1);
 
         Ok((reserve_0, reserve_1))
@@ -287,6 +303,8 @@ impl UniswapV2Pool {
             .decimals()
             .call()
             .await?;
+
+        tracing::trace!(token_a_decimals, token_b_decimals);
 
         Ok((token_a_decimals, token_b_decimals))
     }
@@ -351,6 +369,8 @@ impl UniswapV2Pool {
     }
 
     pub fn get_amount_out(&self, amount_in: U256, reserve_in: U256, reserve_out: U256) -> U256 {
+        tracing::trace!(?amount_in, ?reserve_in, ?reserve_out);
+
         if amount_in.is_zero() || reserve_in.is_zero() || reserve_out.is_zero() {
             return U256::zero();
         }
@@ -358,6 +378,8 @@ impl UniswapV2Pool {
         let amount_in_with_fee = amount_in * U256::from(fee);
         let numerator = amount_in_with_fee * reserve_out;
         let denominator = reserve_in * U256::from(1000) + amount_in_with_fee;
+
+        tracing::trace!(?fee, ?amount_in_with_fee, ?numerator, ?denominator);
 
         numerator / denominator
     }

--- a/src/amm/uniswap_v2/mod.rs
+++ b/src/amm/uniswap_v2/mod.rs
@@ -261,6 +261,7 @@ impl UniswapV2Pool {
         &self,
         middleware: Arc<M>,
     ) -> Result<(u128, u128), AMMError<M>> {
+        tracing::trace!("getting reserves of {}", self.address);
         //Initialize a new instance of the Pool
         let v2_pair = IUniswapV2Pair::new(self.address, middleware);
         // Make a call to get the reserves
@@ -268,6 +269,7 @@ impl UniswapV2Pool {
             Ok(result) => result,
             Err(contract_error) => return Err(AMMError::ContractError(contract_error)),
         };
+        tracing::trace!(reserve_0, reserve_1);
 
         Ok((reserve_0, reserve_1))
     }

--- a/src/amm/uniswap_v3/batch_request/mod.rs
+++ b/src/amm/uniswap_v3/batch_request/mod.rs
@@ -47,6 +47,7 @@ pub async fn get_v3_pool_data_batch_request<M: Middleware>(
     block_number: Option<u64>,
     middleware: Arc<M>,
 ) -> Result<(), AMMError<M>> {
+    tracing::info!(?pool.address, "getting pool data");
     let constructor_args = Token::Tuple(vec![Token::Array(vec![Token::Address(pool.address)])]);
 
     let deployer = IGetUniswapV3PoolDataBatchRequest::deploy(middleware.clone(), constructor_args)?;
@@ -180,6 +181,7 @@ pub async fn sync_v3_pool_batch_request<M: Middleware>(
     pool: &mut UniswapV3Pool,
     middleware: Arc<M>,
 ) -> Result<(), AMMError<M>> {
+    tracing::info!(?pool.address, "syncing pool");
     let constructor_args = Token::Tuple(vec![Token::Address(pool.address)]);
 
     let deployer = ISyncUniswapV3PoolBatchRequest::deploy(middleware.clone(), constructor_args)?;

--- a/src/amm/uniswap_v3/batch_request/mod.rs
+++ b/src/amm/uniswap_v3/batch_request/mod.rs
@@ -234,6 +234,8 @@ pub async fn get_amm_data_batch_request<M: Middleware>(
     block_number: u64,
     middleware: Arc<M>,
 ) -> Result<(), AMMError<M>> {
+    tracing::info!(block_number, "getting data for {} AMMs", amms.len());
+
     let mut target_addresses = vec![];
 
     for amm in amms.iter() {
@@ -279,6 +281,7 @@ pub async fn get_amm_data_batch_request<M: Middleware>(
                                     uniswap_v3_pool.to_owned(),
                                     pool_data,
                                 ) {
+                                    tracing::trace!(?pool);
                                     *uniswap_v3_pool = pool;
                                 }
                             }

--- a/src/amm/uniswap_v3/factory.rs
+++ b/src/amm/uniswap_v3/factory.rs
@@ -149,10 +149,13 @@ impl UniswapV3Factory {
         step: u64,
         middleware: Arc<M>,
     ) -> Result<Vec<AMM>, AMMError<M>> {
+
         //Unwrap can be used here because the creation block was verified within `Dex::new()`
         let mut from_block = self.creation_block;
         let mut aggregated_amms: HashMap<H160, AMM> = HashMap::new();
         let mut ordered_logs: BTreeMap<U64, Vec<Log>> = BTreeMap::new();
+
+        tracing::info!(from_block, to_block, step, "getting all pools from logs");
 
         let mut handles = vec![];
 

--- a/src/amm/uniswap_v3/mod.rs
+++ b/src/amm/uniswap_v3/mod.rs
@@ -185,6 +185,8 @@ impl AutomatedMarketMaker for UniswapV3Pool {
     }
 
     fn simulate_swap(&self, token_in: H160, amount_in: U256) -> Result<U256, SwapSimulationError> {
+        tracing::info!(?token_in, ?amount_in, "simulating swap");
+
         if amount_in.is_zero() {
             return Ok(U256::zero());
         }
@@ -310,7 +312,11 @@ impl AutomatedMarketMaker for UniswapV3Pool {
             }
         }
 
-        Ok((-current_state.amount_calculated).into_raw())
+        let amount_out = (-current_state.amount_calculated).into_raw();
+
+        tracing::trace!(?amount_out);
+
+        Ok(amount_out)
     }
 
     fn simulate_swap_mut(
@@ -318,6 +324,8 @@ impl AutomatedMarketMaker for UniswapV3Pool {
         token_in: H160,
         amount_in: U256,
     ) -> Result<U256, SwapSimulationError> {
+        tracing::info!(?token_in, ?amount_in, "simulating swap");
+
         if amount_in.is_zero() {
             return Ok(U256::zero());
         }
@@ -448,7 +456,11 @@ impl AutomatedMarketMaker for UniswapV3Pool {
         self.sqrt_price = current_state.sqrt_price_x_96;
         self.tick = current_state.tick;
 
-        Ok((-current_state.amount_calculated).into_raw())
+        let amount_out = (-current_state.amount_calculated).into_raw();
+
+        tracing::trace!(?amount_out);
+
+        Ok(amount_out)
     }
 
     fn get_token_out(&self, token_in: H160) -> H160 {
@@ -792,7 +804,8 @@ impl UniswapV3Pool {
     }
 
     pub fn modify_position(&mut self, tick_lower: i32, tick_upper: i32, liquidity_delta: i128) {
-        //We are only using this function when a mint or burn event is emitted, therefore we do not need to checkTicks as that has happened before the event is emitted
+        //We are only using this function when a mint or burn event is emitted,
+        //therefore we do not need to checkTicks as that has happened before the event is emitted
         self.update_position(tick_lower, tick_upper, liquidity_delta);
 
         if liquidity_delta != 0 {

--- a/src/discovery/erc_4626.rs
+++ b/src/discovery/erc_4626.rs
@@ -45,7 +45,7 @@ pub async fn discover_erc_4626_vaults<M: Middleware>(
             to_block = current_block;
         }
 
-        tracing::trace!("processing blocks {}-{}", from_block, to_block);
+        tracing::info!("searching blocks {}-{}", from_block, to_block);
 
         let block_filter = block_filter.clone();
         //TODO: use a better method, this is just quick and scrappy
@@ -94,10 +94,10 @@ pub async fn discover_erc_4626_vaults<M: Middleware>(
 
         for log in logs {
             if log.topics[0] == DEPOSIT_EVENT_SIGNATURE {
-                tracing::trace!(address = ?log.address, "deposit event found");
+                tracing::info!(address = ?log.address, "deposit event found");
                 adheres_to_deposit_event.insert(log.address);
             } else if log.topics[0] == WITHDRAW_EVENT_SIGNATURE {
-                tracing::trace!(address = ?log.address, "withdraw event found");
+                tracing::info!(address = ?log.address, "withdraw event found");
                 adheres_to_withdraw_event.insert(log.address);
             }
         }
@@ -105,7 +105,7 @@ pub async fn discover_erc_4626_vaults<M: Middleware>(
 
     for address in adheres_to_deposit_event.iter() {
         if adheres_to_withdraw_event.contains(address) {
-            tracing::trace!(?address, "found a pair of matching deposit/withdraw events");
+            tracing::info!(?address, "found a pair of matching deposit/withdraw events");
             identified_addresses.insert(address);
         }
     }

--- a/src/discovery/erc_4626.rs
+++ b/src/discovery/erc_4626.rs
@@ -5,7 +5,6 @@ use ethers::{
     types::{Filter, U256},
 };
 use regex::Regex;
-use spinoff::{spinners, Color, Spinner};
 
 use crate::{
     amm::erc_4626::{ERC4626Vault, DEPOSIT_EVENT_SIGNATURE, WITHDRAW_EVENT_SIGNATURE},
@@ -21,14 +20,11 @@ pub async fn discover_erc_4626_vaults<M: Middleware>(
     middleware: Arc<M>,
     step: u64,
 ) -> Result<Vec<ERC4626Vault>, AMMError<M>> {
-    let spinner = Spinner::new(
-        spinners::Dots,
-        "Discovering new ERC 4626 vaults...",
-        Color::Blue,
-    );
+    tracing::info!(step, "discovering new ERC 4626 vaults");
 
-    let block_filter =
-        Filter::new().topic0(vec![DEPOSIT_EVENT_SIGNATURE, WITHDRAW_EVENT_SIGNATURE]);
+    let event_signatures = vec![DEPOSIT_EVENT_SIGNATURE, WITHDRAW_EVENT_SIGNATURE];
+    let block_filter = Filter::new().topic0(event_signatures.clone());
+    tracing::trace!(?event_signatures);
 
     let current_block = middleware
         .get_block_number()
@@ -49,6 +45,8 @@ pub async fn discover_erc_4626_vaults<M: Middleware>(
             to_block = current_block;
         }
 
+        tracing::trace!("processing blocks {}-{}", from_block, to_block);
+
         let block_filter = block_filter.clone();
         //TODO: use a better method, this is just quick and scrappy
         let fallback_block_filter = block_filter.clone();
@@ -62,6 +60,8 @@ pub async fn discover_erc_4626_vaults<M: Middleware>(
                 logs
             }
             Err(err) => {
+                tracing::warn!("error getting logs");
+
                 let mut block_range = Vec::new();
                 for m in HEX_REGEX.find_iter(&err.to_string()) {
                     let value = U256::from_str(m.as_str()).map_err(|_| AMMError::FromHexError)?;
@@ -71,6 +71,11 @@ pub async fn discover_erc_4626_vaults<M: Middleware>(
                 if block_range.is_empty() {
                     return Err(AMMError::MiddlewareError(err));
                 } else {
+                    tracing::warn!(
+                        "getting logs from blocks {}-{} instead",
+                        block_range[0],
+                        block_range[1]
+                    );
                     let logs = middleware
                         .get_logs(
                             &fallback_block_filter
@@ -89,8 +94,10 @@ pub async fn discover_erc_4626_vaults<M: Middleware>(
 
         for log in logs {
             if log.topics[0] == DEPOSIT_EVENT_SIGNATURE {
+                tracing::trace!(address = ?log.address, "deposit event found");
                 adheres_to_deposit_event.insert(log.address);
             } else if log.topics[0] == WITHDRAW_EVENT_SIGNATURE {
+                tracing::trace!(address = ?log.address, "withdraw event found");
                 adheres_to_withdraw_event.insert(log.address);
             }
         }
@@ -98,6 +105,7 @@ pub async fn discover_erc_4626_vaults<M: Middleware>(
 
     for address in adheres_to_deposit_event.iter() {
         if adheres_to_withdraw_event.contains(address) {
+            tracing::trace!(?address, "found a pair of matching deposit/withdraw events");
             identified_addresses.insert(address);
         }
     }
@@ -114,6 +122,6 @@ pub async fn discover_erc_4626_vaults<M: Middleware>(
         }
     }
 
-    spinner.success("All vaults discovered");
+    tracing::info!("all vaults discovered");
     Ok(vaults)
 }

--- a/src/discovery/factory.rs
+++ b/src/discovery/factory.rs
@@ -68,7 +68,7 @@ pub async fn discover_factories<M: Middleware>(
             target_block = current_block;
         }
 
-        tracing::trace!("processing blocks {}-{}", from_block, target_block);
+        tracing::info!("searching blocks {}-{}", from_block, target_block);
 
         let block_filter = block_filter.clone();
         let logs = middleware
@@ -105,7 +105,7 @@ pub async fn discover_factories<M: Middleware>(
                     }
                 }
 
-                tracing::trace!("discovered new factory {}", log.address);
+                tracing::info!(address = ?log.address, "discovered new factory");
                 identified_factories.insert(log.address, (factory, 0));
             }
         }
@@ -114,23 +114,13 @@ pub async fn discover_factories<M: Middleware>(
     }
 
     let mut filtered_factories = vec![];
-    tracing::trace!("checking threshold");
+    tracing::trace!(number_of_amms_threshold, "checking threshold");
     for (address, (factory, amms_length)) in identified_factories {
         if amms_length >= number_of_amms_threshold {
-            tracing::trace!(
-                threshold = number_of_amms_threshold,
-                "factory {} has {} AMMs => adding",
-                address,
-                amms_length
-            );
+            tracing::trace!("factory {} has {} AMMs => adding", address, amms_length);
             filtered_factories.push(factory);
         } else {
-            tracing::trace!(
-                threshold = number_of_amms_threshold,
-                "factory {} has {} AMMs => skipping",
-                address,
-                amms_length
-            );
+            tracing::trace!("factory {} has {} AMMs => skipping", address, amms_length);
         }
     }
 

--- a/src/discovery/factory.rs
+++ b/src/discovery/factory.rs
@@ -4,7 +4,6 @@ use ethers::{
     providers::Middleware,
     types::{Filter, H160, H256},
 };
-use spinoff::{spinners, Color, Spinner};
 
 use crate::{
     amm::{self, factory::Factory},
@@ -37,13 +36,14 @@ pub async fn discover_factories<M: Middleware>(
     middleware: Arc<M>,
     step: u64,
 ) -> Result<Vec<Factory>, AMMError<M>> {
-    let spinner = Spinner::new(spinners::Dots, "Discovering new factories...", Color::Blue);
+    tracing::info!(number_of_amms_threshold, step, "discovering new factories",);
 
     let mut event_signatures = vec![];
 
     for factory in factories {
         event_signatures.push(factory.discovery_event_signature());
     }
+    tracing::trace!(?event_signatures);
 
     let block_filter = Filter::new().topic0(event_signatures);
 
@@ -68,6 +68,8 @@ pub async fn discover_factories<M: Middleware>(
             target_block = current_block;
         }
 
+        tracing::trace!("processing blocks {}-{}", from_block, target_block);
+
         let block_filter = block_filter.clone();
         let logs = middleware
             .get_logs(&block_filter.from_block(from_block).to_block(target_block))
@@ -75,8 +77,14 @@ pub async fn discover_factories<M: Middleware>(
             .map_err(AMMError::MiddlewareError)?;
 
         for log in logs {
+            tracing::trace!("found matching event at factory {}", log.address);
             if let Some((_, amms_length)) = identified_factories.get_mut(&log.address) {
                 *amms_length += 1;
+                tracing::trace!(
+                    "increasing factory {} AMMs to {}",
+                    log.address,
+                    *amms_length
+                );
             } else {
                 let mut factory = Factory::try_from(log.topics[0])?;
 
@@ -97,6 +105,7 @@ pub async fn discover_factories<M: Middleware>(
                     }
                 }
 
+                tracing::trace!("discovered new factory {}", log.address);
                 identified_factories.insert(log.address, (factory, 0));
             }
         }
@@ -105,12 +114,26 @@ pub async fn discover_factories<M: Middleware>(
     }
 
     let mut filtered_factories = vec![];
-    for (_, (factory, amms_length)) in identified_factories {
+    tracing::trace!("checking threshold");
+    for (address, (factory, amms_length)) in identified_factories {
         if amms_length >= number_of_amms_threshold {
+            tracing::trace!(
+                threshold = number_of_amms_threshold,
+                "factory {} has {} AMMs => adding",
+                address,
+                amms_length
+            );
             filtered_factories.push(factory);
+        } else {
+            tracing::trace!(
+                threshold = number_of_amms_threshold,
+                "factory {} has {} AMMs => skipping",
+                address,
+                amms_length
+            );
         }
     }
 
-    spinner.success("All factories discovered");
+    tracing::info!("all factories discovered");
     Ok(filtered_factories)
 }

--- a/src/filters/value.rs
+++ b/src/filters/value.rs
@@ -11,8 +11,6 @@ use crate::{
     errors::AMMError,
 };
 
-use spinoff::{spinners, Color, Spinner};
-
 pub const U256_10_POW_18: U256 = U256([1000000000000000000, 0, 0, 0]);
 pub const U256_10_POW_6: U256 = U256([1000000, 0, 0, 0]);
 
@@ -28,11 +26,7 @@ pub async fn filter_amms_below_usd_threshold<M: Middleware>(
     step: usize,
     middleware: Arc<M>,
 ) -> Result<Vec<AMM>, AMMError<M>> {
-    let spinner = Spinner::new(
-        spinners::Dots,
-        "Filtering AMMs below USD threshold...",
-        Color::Blue,
-    );
+    tracing::info!("filtering AMMs below USD threshold");
 
     let weth_usd_price = usd_weth_pool.calculate_price(weth)?;
 
@@ -58,7 +52,7 @@ pub async fn filter_amms_below_usd_threshold<M: Middleware>(
         }
     }
 
-    spinner.success("All AMMs filtered");
+    tracing::info!("all AMMs filtered");
     Ok(filtered_amms)
 }
 
@@ -73,11 +67,7 @@ pub async fn filter_amms_below_weth_threshold<M: Middleware>(
     step: usize,
     middleware: Arc<M>,
 ) -> Result<Vec<AMM>, AMMError<M>> {
-    let spinner = Spinner::new(
-        spinners::Dots,
-        "Filtering AMMs below weth threshold...",
-        Color::Blue,
-    );
+    tracing::info!("filtering AMMs below weth threshold");
 
     let mut filtered_amms = vec![];
 
@@ -98,7 +88,7 @@ pub async fn filter_amms_below_weth_threshold<M: Middleware>(
         }
     }
 
-    spinner.success("All AMMs filtered");
+    tracing::info!("All AMMs filtered");
     Ok(filtered_amms)
 }
 

--- a/src/state_space/state.rs
+++ b/src/state_space/state.rs
@@ -104,6 +104,8 @@ where
     where
         <P as Middleware>::Provider: PubsubClient,
     {
+        tracing::info!(last_synced_block, channel_buffer, "listening for new blocks");
+
         let state = self.state.clone();
         let middleware = self.middleware.clone();
         let stream_middleware: Arc<P> = self.stream_middleware.clone();
@@ -131,11 +133,13 @@ where
         let new_block_handle: JoinHandle<Result<(), StateSpaceError<M, P>>> =
             tokio::spawn(async move {
                 while let Some(block) = stream_rx.recv().await {
+                    tracing::info!(?block, "received new block");
                     if let Some(chain_head_block_number) = block.number {
                         let chain_head_block_number = chain_head_block_number.as_u64();
 
                         //If there is a reorg, unwind state changes from last_synced block to the chain head block number
                         if chain_head_block_number <= last_synced_block {
+                            tracing::trace!(chain_head_block_number, last_synced_block, "reorg detected, unwinding state changes");
                             unwind_state_changes(
                                 state.clone(),
                                 state_change_cache.clone(),
@@ -204,6 +208,8 @@ where
     where
         <P as Middleware>::Provider: PubsubClient,
     {
+        tracing::info!(last_synced_block, channel_buffer, "listening for state changes");
+
         let state = self.state.clone();
         let middleware = self.middleware.clone();
         let stream_middleware: Arc<P> = self.stream_middleware.clone();
@@ -232,11 +238,13 @@ where
         let updated_amms_handle: JoinHandle<Result<(), StateSpaceError<M, P>>> =
             tokio::spawn(async move {
                 while let Some(block) = stream_rx.recv().await {
+                    tracing::info!(?block, "received new block");
                     if let Some(chain_head_block_number) = block.number {
                         let chain_head_block_number = chain_head_block_number.as_u64();
 
                         //If there is a reorg, unwind state changes from last_synced block to the chain head block number
                         if chain_head_block_number <= last_synced_block {
+                            tracing::trace!(chain_head_block_number, last_synced_block, "reorg detected, unwinding state changes");
                             unwind_state_changes(
                                 state.clone(),
                                 state_change_cache.clone(),
@@ -300,6 +308,8 @@ where
     where
         <P as Middleware>::Provider: PubsubClient,
     {
+        tracing::info!(last_synced_block, channel_buffer, "listening for updates");
+
         let state = self.state.clone();
         let middleware = self.middleware.clone();
         let stream_middleware: Arc<P> = self.stream_middleware.clone();
@@ -325,11 +335,13 @@ where
         let new_block_handle: JoinHandle<Result<(), StateSpaceError<M, P>>> =
             tokio::spawn(async move {
                 while let Some(block) = stream_rx.recv().await {
+                    tracing::info!(?block, "received new block");
                     if let Some(chain_head_block_number) = block.number {
                         let chain_head_block_number = chain_head_block_number.as_u64();
 
                         //If there is a reorg, unwind state changes from last_synced block to the chain head block number
                         if chain_head_block_number <= last_synced_block {
+                            tracing::trace!(chain_head_block_number, last_synced_block, "reorg detected, unwinding state changes");
                             unwind_state_changes(
                                 state.clone(),
                                 state_change_cache.clone(),

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -8,7 +8,6 @@ use crate::{
 
 use ethers::providers::Middleware;
 
-use spinoff::{spinners, Color, Spinner};
 use std::{panic::resume_unwind, sync::Arc};
 pub mod checkpoint;
 
@@ -18,7 +17,12 @@ pub async fn sync_amms<M: 'static + Middleware>(
     checkpoint_path: Option<&str>,
     step: u64,
 ) -> Result<(Vec<AMM>, u64), AMMError<M>> {
-    let spinner = Spinner::new(spinners::Dots, "Syncing AMMs...", Color::Blue);
+    tracing::info!(
+        step,
+        checkpoint_path,
+        "syncing AMMs of {} factories",
+        factories.len()
+    );
 
     let current_block = middleware
         .get_block_number()
@@ -36,6 +40,7 @@ pub async fn sync_amms<M: 'static + Middleware>(
 
         //Spawn a new thread to get all pools and sync data for each dex
         handles.push(tokio::spawn(async move {
+            tracing::trace!("syncing factory {}", factory.address());
             //Get all of the amms from the factory
             let mut amms: Vec<AMM> = factory
                 .get_all_amms(Some(current_block), middleware.clone(), step)
@@ -45,7 +50,7 @@ pub async fn sync_amms<M: 'static + Middleware>(
             //Clean empty pools
             amms = remove_empty_amms(amms);
 
-            // If the factory is UniswapV2, set the fee for each pool according to the factory fee
+            //If the factory is UniswapV2, set the fee for each pool according to the factory fee
             if let Factory::UniswapV2Factory(factory) = factory {
                 for amm in amms.iter_mut() {
                     if let AMM::UniswapV2Pool(ref mut pool) = amm {
@@ -82,7 +87,8 @@ pub async fn sync_amms<M: 'static + Middleware>(
             checkpoint_path,
         )?;
     }
-    spinner.success("AMMs synced");
+
+    tracing::info!("AMMs synced");
 
     //Return the populated aggregated amms vec
     Ok((aggregated_amms, current_block))

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -40,7 +40,7 @@ pub async fn sync_amms<M: 'static + Middleware>(
 
         //Spawn a new thread to get all pools and sync data for each dex
         handles.push(tokio::spawn(async move {
-            tracing::trace!("syncing factory {}", factory.address());
+            tracing::info!("syncing factory {}", factory.address());
             //Get all of the amms from the factory
             let mut amms: Vec<AMM> = factory
                 .get_all_amms(Some(current_block), middleware.clone(), step)

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -30,6 +30,8 @@ pub async fn sync_amms<M: 'static + Middleware>(
         .map_err(AMMError::MiddlewareError)?
         .as_u64();
 
+    tracing::trace!(current_block);
+
     //Aggregate the populated pools from each thread
     let mut aggregated_amms: Vec<AMM> = vec![];
     let mut handles = vec![];


### PR DESCRIPTION
Example 1:

```
RUST_LOG=amms=info ETHEREUM_RPC_ENDPOINT=https://eth-mainnet.g.alchemy.com/v2/<key> cargo run --example discover-factories
```

```
2023-08-18T11:51:14.010291Z  INFO amms::discovery::factory: searching blocks 10000000-10049999
2023-08-18T11:51:14.387740Z  INFO amms::discovery::factory: discovered new factory address=0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f
2023-08-18T11:51:14.387827Z  INFO amms::discovery::factory: searching blocks 10050000-10099999
2023-08-18T11:51:14.816924Z  INFO amms::discovery::factory: searching blocks 10100000-10149999
2023-08-18T11:51:15.148548Z  INFO amms::discovery::factory: searching blocks 10150000-10199999
2023-08-18T11:51:15.410583Z  INFO amms::discovery::factory: discovered new factory address=0xbf85fdce9e4fa7d5a0177559150b15bf7f1bfd93
2023-08-18T11:51:15.410788Z  INFO amms::discovery::factory: searching blocks 10200000-10249999
2023-08-18T11:51:15.839061Z  INFO amms::discovery::factory: discovered new factory address=0x96fa2425defa8f56e9fd912f4f715d57e6424498
2023-08-18T11:51:15.839115Z  INFO amms::discovery::factory: discovered new factory address=0x60044f45b425ee2284bbc8c56f74e7e0df2228f0
```

Example 2:

```
RUST_LOG=amms=trace ETHEREUM_RPC_ENDPOINT=https://eth-mainnet.g.alchemy.com/v2/<key> cargo run --example simulate-swap
```

```
2023-08-18T12:14:32.994086Z  INFO amms::amm::uniswap_v2::batch_request: getting pool data pool.address=0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc
2023-08-18T12:14:33.358597Z  INFO amms::amm::uniswap_v2: simulating swap token_in=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 amount_in=10000
2023-08-18T12:14:33.358675Z TRACE amms::amm::uniswap_v2: amount_in=10000 reserve_in=16758863713340495765700 reserve_out=28209594590739
2023-08-18T12:14:33.358726Z TRACE amms::amm::uniswap_v2: fee=997 amount_in_with_fee=9970000 numerator=281249658069667830000 denominator=16758863713340495775670000
Amount out: 0
```

(because `281249658069667830000 / 16758863713340495775670000 = 0.0000167821`)

closes #85 