### PR TITLE
Fix max batch size for V3

### DIFF
--- a/src/amm/uniswap_v3/factory.rs
+++ b/src/amm/uniswap_v3/factory.rs
@@ -98,7 +98,7 @@ impl AutomatedMarketMakerFactory for UniswapV3Factory {
         middleware: Arc<M>,
     ) -> Result<(), AMMError<M>> {
         if let Some(block_number) = block_number {
-            let step = 127; //Max batch size for call
+            let step = 76; //Max batch size for call
             for amm_chunk in amms.chunks_mut(step) {
                 batch_request::get_amm_data_batch_request(
                     amm_chunk,


### PR DESCRIPTION
For uni-v3 sync all pools work fine, but sync from checkpoint failed with error:
`(code: -32000, message: max code size exceeded, data: None)`

It happened because of mismatch of batch size for uni-v3 
In sync/mod.rs it's correct:
https://github.com/darkforestry/amms-rs/blob/00b267252db0237de82754882df09553d7684296/src/sync/mod.rs#L122

But in uniswap_v3/factory.rs it looks like copypasta from uni-v2:
https://github.com/darkforestry/amms-rs/blob/00b267252db0237de82754882df09553d7684296/src/amm/uniswap_v3/factory.rs#L101