### PR TITLE
Fix the error that contract creation code storage out of gas

### DIFF
--- a/contracts/GetERC4626VaultDataBatchRequest.sol
+++ b/contracts/GetERC4626VaultDataBatchRequest.sol
@@ -68,7 +68,7 @@ contract GetERC4626VaultDataBatchRequest {
             (
                 bool assetTokenDecimalsSuccess,
                 bytes memory assetTokenDecimalsData
-            ) = vaultData.assetToken.call(
+            ) = vaultData.assetToken.call{gas: 20000}(
                     abi.encodeWithSignature("decimals()")
                 );
 

--- a/contracts/GetUniswapV2PoolDataBatchRequest.sol
+++ b/contracts/GetUniswapV2PoolDataBatchRequest.sol
@@ -9,11 +9,7 @@ interface IUniswapV2Pair {
     function getReserves()
         external
         view
-        returns (
-            uint112 reserve0,
-            uint112 reserve1,
-            uint32 blockTimestampLast
-        );
+        returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast);
 }
 
 interface IERC20 {
@@ -55,7 +51,9 @@ contract GetUniswapV2PoolDataBatchRequest {
             (
                 bool tokenADecimalsSuccess,
                 bytes memory tokenADecimalsData
-            ) = poolData.tokenA.call(abi.encodeWithSignature("decimals()"));
+            ) = poolData.tokenA.call{gas: 20000}(
+                    abi.encodeWithSignature("decimals()")
+                );
 
             if (tokenADecimalsSuccess) {
                 uint256 tokenADecimals;
@@ -82,7 +80,9 @@ contract GetUniswapV2PoolDataBatchRequest {
             (
                 bool tokenBDecimalsSuccess,
                 bytes memory tokenBDecimalsData
-            ) = poolData.tokenB.call(abi.encodeWithSignature("decimals()"));
+            ) = poolData.tokenB.call{gas: 20000}(
+                    abi.encodeWithSignature("decimals()")
+                );
 
             if (tokenBDecimalsSuccess) {
                 uint256 tokenBDecimals;

--- a/contracts/GetUniswapV3PoolDataBatchRequest.sol
+++ b/contracts/GetUniswapV3PoolDataBatchRequest.sol
@@ -25,7 +25,9 @@ interface IUniswapV3Pool {
             bool unlocked
         );
 
-    function ticks(int24 tick)
+    function ticks(
+        int24 tick
+    )
         external
         view
         returns (
@@ -83,7 +85,9 @@ contract GetUniswapV3PoolDataBatchRequest {
             (
                 bool tokenADecimalsSuccess,
                 bytes memory tokenADecimalsData
-            ) = poolData.tokenA.call(abi.encodeWithSignature("decimals()"));
+            ) = poolData.tokenA.call{gas: 20000}(
+                    abi.encodeWithSignature("decimals()")
+                );
 
             if (tokenADecimalsSuccess) {
                 uint256 tokenADecimals;
@@ -109,7 +113,9 @@ contract GetUniswapV3PoolDataBatchRequest {
             (
                 bool tokenBDecimalsSuccess,
                 bytes memory tokenBDecimalsData
-            ) = poolData.tokenB.call(abi.encodeWithSignature("decimals()"));
+            ) = poolData.tokenB.call{gas: 20000}(
+                    abi.encodeWithSignature("decimals()")
+                );
 
             if (tokenBDecimalsSuccess) {
                 uint256 tokenBDecimals;

--- a/contracts/GetWethValueInPoolBatchRequest.sol
+++ b/contracts/GetWethValueInPoolBatchRequest.sol
@@ -464,7 +464,7 @@ contract GetWethValueInPoolBatchRequest {
         address token
     ) internal returns (uint8, bool) {
         (bool tokenDecimalsSuccess, bytes memory tokenDecimalsData) = token
-            .call(abi.encodeWithSignature("decimals()"));
+            .call{gas: 20000}(abi.encodeWithSignature("decimals()"));
 
         if (tokenDecimalsSuccess) {
             uint256 tokenDecimals;


### PR DESCRIPTION
Fix error caused by querying non-standard ERC20 contracts without Decimal function
```
Error: (code: -32000, message: contract creation code storage out of gas, data: e.g. 0xc0ca776fe52)
```
Example: 0xc0ca776fe52eC92b1D5603cAadf148DbD8C22a80

Limit the gas limit of the call, 20000 is already enough for normal contract calls.

The 20000 limit was a random thought, because I tested that 5000 would affect the normal token lookup, so I set it a bit bigger.
However, I don't understand why you don't use try catch, maybe it's better that way, maybe I didn't think about it in some places.


I don't have forge build to generate the json file, please remember that you need to forge build and replace it with the corresponding file under src.