### PR TITLE
Update ethers to 2.0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 
 
 [dependencies]
-ethers = { version = "2.0.8", default-features = true, features = ["abigen", "ws", "ipc", "rustls"] }
+ethers = { version = "2.0.11", default-features = true, features = ["abigen", "ws", "ipc", "rustls"] }
 tokio = { version = "1.29.1", features = ["full"] }
 futures = "0.3.28"
 indicatif = "0.17.5"


### PR DESCRIPTION
Bump ethers to latest

Seems like cargo.lock already had latest

UPD: oh I found out that dependencies specified without prefix are treated as having prefix ^ so there is no need to update