### PR TITLE
feat: optimize sync + checkpoint sync v3 + better tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,7 @@ dependencies = [
  "ethers",
  "eyre",
  "futures",
+ "indicatif",
  "lazy_static",
  "num-bigfloat",
  "regex",
@@ -743,6 +744,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "const-hex"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,6 +1090,12 @@ checksum = "c533630cf40e9caa44bd91aadc88a75d75a4c3a12b4cfde353cbed41daa1e1f1"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -2102,6 +2122,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
+dependencies = [
+ "console",
+ "instant",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+]
+
+[[package]]
 name = "infer"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2662,6 +2695,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "object"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3073,6 +3112,12 @@ checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "powerfmt"
@@ -4644,6 +4689,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ criterion = "0.5.1"
 ethers = { version = "2.0.11", default-features = true, features = ["abigen", "ws", "ipc", "rustls"] } # TODO: update this to aloy
 eyre = "0.6.11"
 futures = "0.3.30"
+indicatif = "0.17.8"
 lazy_static = "1.4.0" #TODO: why do we have this
 num-bigfloat = "1.7.0"
 regex = "1.9.1"

--- a/examples/sync-amms.rs
+++ b/examples/sync-amms.rs
@@ -35,7 +35,7 @@ async fn main() -> eyre::Result<()> {
         //Add UniswapV3
         Factory::UniswapV3Factory(UniswapV3Factory::new(
             H160::from_str("0x1F98431c8aD98523631AE4a59f267346ea31F984")?,
-            185,
+            12369621,
         )),
     ];
 

--- a/src/amm/erc_4626/mod.rs
+++ b/src/amm/erc_4626/mod.rs
@@ -218,27 +218,33 @@ impl ERC4626Vault {
         let vault = IERC4626Vault::new(self.vault_token, middleware);
         // Get the total assets in the vault
         let total_assets = if let Some(block) = block {
-            match vault.total_assets().block(block).call().await {
-                Ok(total_assets) => total_assets,
-                Err(e) => return Err(AMMError::ContractError(e)),
-            }
+            vault
+                .total_assets()
+                .block(block)
+                .call()
+                .await
+                .map_err(AMMError::ContractError)?
         } else {
-            match vault.total_assets().call().await {
-                Ok(total_assets) => total_assets,
-                Err(e) => return Err(AMMError::ContractError(e)),
-            }
+            vault
+                .total_assets()
+                .call()
+                .await
+                .map_err(AMMError::ContractError)?
         };
         // Get the total supply of the vault token
         let total_supply = if let Some(block) = block {
-            match vault.total_supply().block(block).call().await {
-                Ok(total_supply) => total_supply,
-                Err(e) => return Err(AMMError::ContractError(e)),
-            }
+            vault
+                .total_supply()
+                .block(block)
+                .call()
+                .await
+                .map_err(AMMError::ContractError)?
         } else {
-            match vault.total_supply().call().await {
-                Ok(total_supply) => total_supply,
-                Err(e) => return Err(AMMError::ContractError(e)),
-            }
+            vault
+                .total_supply()
+                .call()
+                .await
+                .map_err(AMMError::ContractError)?
         };
 
         Ok((total_supply, total_assets))

--- a/src/amm/uniswap_v2/mod.rs
+++ b/src/amm/uniswap_v2/mod.rs
@@ -297,15 +297,18 @@ impl UniswapV2Pool {
         let v2_pair = IUniswapV2Pair::new(self.address, middleware);
         // Make a call to get the reserves
         let (reserve_0, reserve_1, _) = if let Some(block) = block {
-            match v2_pair.get_reserves().block(block).call().await {
-                Ok(result) => result,
-                Err(contract_error) => return Err(AMMError::ContractError(contract_error)),
-            }
+            v2_pair
+                .get_reserves()
+                .block(block)
+                .call()
+                .await
+                .map_err(AMMError::ContractError)?
         } else {
-            match v2_pair.get_reserves().call().await {
-                Ok(result) => result,
-                Err(contract_error) => return Err(AMMError::ContractError(contract_error)),
-            }
+            v2_pair
+                .get_reserves()
+                .call()
+                .await
+                .map_err(AMMError::ContractError)?
         };
 
         tracing::trace!(reserve_0, reserve_1);

--- a/src/amm/uniswap_v3/batch_request/mod.rs
+++ b/src/amm/uniswap_v3/batch_request/mod.rs
@@ -34,7 +34,7 @@ fn populate_pool_data_from_tokens(
     pool.token_a_decimals = tokens[1].to_owned().into_uint()?.as_u32() as u8;
     pool.token_b = tokens[2].to_owned().into_address()?;
     pool.token_b_decimals = tokens[3].to_owned().into_uint()?.as_u32() as u8;
-    pool.liquidity = tokens[4].to_owned().into_uint()?.as_u128();
+    pool.liquidity = tokens[4].to_owned().into_uint()?.as_u128() as i128;
     pool.sqrt_price = tokens[5].to_owned().into_uint()?;
     pool.tick = I256::from_raw(tokens[6].to_owned().into_int()?).as_i32();
     pool.tick_spacing = I256::from_raw(tokens[7].to_owned().into_int()?).as_i32();
@@ -211,7 +211,7 @@ pub async fn sync_v3_pool_batch_request<M: Middleware>(
                     .to_owned()
                     .into_uint()
                     .ok_or(AMMError::BatchRequestError(pool.address))?
-                    .as_u128();
+                    .as_u128() as i128;
                 pool.sqrt_price = pool_data[1]
                     .to_owned()
                     .into_uint()

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -107,4 +107,8 @@ pub enum CheckpointError {
     SerdeJsonError(#[from] serde_json::error::Error),
     #[error("IO error")]
     IOError(#[from] std::io::Error),
+    #[error("Error Populating AMM")]
+    ErrorPopulatingAMM,
+    #[error("Join error")]
+    JoinError(#[from] JoinError),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,6 @@ pub mod amm;
 pub mod discovery;
 pub mod errors;
 pub mod filters;
+pub mod progress_bar;
 pub mod state_space;
 pub mod sync;

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -1,0 +1,44 @@
+use std::fmt::Write;
+
+pub fn eta_key(state: &indicatif::ProgressState, f: &mut dyn Write) {
+    write!(f, "{:.1}s", state.eta().as_secs_f64()).unwrap()
+}
+
+#[macro_export]
+macro_rules! init_progress {
+    ($local:expr, $label:expr) => {{
+        let pb = indicatif::ProgressBar::new($local as u64);
+        let mut template =
+            "{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len} ".to_string();
+        template += $label;
+        template += " ({eta})";
+        pb.set_style(
+            indicatif::ProgressStyle::with_template(&template)
+                .unwrap()
+                .with_key("eta", $crate::progress_bar::eta_key)
+                .progress_chars("#>-"),
+        );
+        pb
+    }};
+}
+
+#[macro_export]
+macro_rules! update_progress {
+    ($pb:ident, $index:expr) => {
+        $pb.set_position(($index + 1) as u64);
+    };
+}
+
+#[macro_export]
+macro_rules! update_progress_by_one {
+    ($pb:ident) => {
+        $pb.inc(1);
+    };
+}
+
+#[macro_export]
+macro_rules! finish_progress {
+    ($pb:ident) => {
+        $pb.finish();
+    };
+}

--- a/src/sync/checkpoint.rs
+++ b/src/sync/checkpoint.rs
@@ -282,7 +282,9 @@ pub fn deconstruct_checkpoint(checkpoint_path: &str) -> Result<(Vec<AMM>, u64), 
 
 #[cfg(test)]
 mod test {
+
     #[tokio::test(flavor = "multi_thread")]
+    #[ignore] // requires building `src/sync/checkpoint_test.json` prior to testing.
     pub async fn test_sync_amms_from_checkpoint() -> eyre::Result<()> {
         use crate::amm::AutomatedMarketMaker;
         use crate::sync::{AMM, AMM::UniswapV3Pool};

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -4,12 +4,14 @@ use crate::{
         uniswap_v2, uniswap_v3, AutomatedMarketMaker, AMM,
     },
     errors::AMMError,
-    filters,
+    filters, finish_progress, init_progress,
+    sync::checkpoint::sync_amms_from_checkpoint,
 };
 
+use crate::update_progress_by_one;
 use ethers::providers::Middleware;
-
-use std::{panic::resume_unwind, sync::Arc};
+use indicatif::MultiProgress;
+use std::sync::Arc;
 pub mod checkpoint;
 /// Syncs all AMMs from the supplied factories.
 ///
@@ -32,57 +34,47 @@ pub async fn sync_amms<M: 'static + Middleware>(
         .map_err(AMMError::MiddlewareError)?
         .as_u64();
 
+    if let Some(checkpoint_path) = checkpoint_path {
+        if std::fs::File::open(checkpoint_path).is_ok() {
+            let (_, amms, synced_block) =
+                sync_amms_from_checkpoint(checkpoint_path, step, middleware).await?;
+            return Ok((amms, synced_block));
+        }
+    }
+
     //Aggregate the populated pools from each thread
     let mut aggregated_amms: Vec<AMM> = vec![];
-    let mut handles = vec![];
 
     //For each dex supplied, get all pair created events and get reserve values
     for factory in factories.clone() {
         let middleware = middleware.clone();
 
         //Spawn a new thread to get all pools and sync data for each dex
-        handles.push(tokio::spawn(async move {
-            tracing::info!(?factory, "Getting all AMMs from factory");
-            //Get all of the amms from the factory
-            let mut amms = factory
-                .get_all_amms(Some(current_block), middleware.clone(), step)
-                .await?;
 
-            tracing::info!(?factory, "Populating AMMs from factory");
-            populate_amms(&mut amms, current_block, middleware.clone()).await?;
+        tracing::info!(?factory, "Getting all AMMs from factory");
+        //Get all of the amms from the factory
+        let mut amms = factory
+            .get_all_amms(Some(current_block), middleware.clone(), step)
+            .await?;
 
-            //Clean empty pools
-            amms = filters::filter_empty_amms(amms);
+        tracing::info!(?factory, "Populating AMMs from factory");
+        populate_amms(&mut amms, current_block, middleware.clone()).await?;
 
-            //If the factory is UniswapV2, set the fee for each pool according to the factory fee
-            if let Factory::UniswapV2Factory(factory) = factory {
-                for amm in amms.iter_mut() {
-                    if let AMM::UniswapV2Pool(ref mut pool) = amm {
-                        pool.fee = factory.fee;
-                    }
-                }
-            }
+        //Clean empty pools
+        amms = filters::filter_empty_amms(amms);
 
-            Ok::<_, AMMError<M>>(amms)
-        }));
-    }
-
-    for handle in handles {
-        match handle.await {
-            Ok(sync_result) => aggregated_amms.extend(sync_result?),
-            Err(err) => {
-                {
-                    if err.is_panic() {
-                        // Resume the panic on the main task
-                        resume_unwind(err.into_panic());
-                    }
+        //If the factory is UniswapV2, set the fee for each pool according to the factory fee
+        if let Factory::UniswapV2Factory(factory) = factory {
+            for amm in amms.iter_mut() {
+                if let AMM::UniswapV2Pool(ref mut pool) = amm {
+                    pool.fee = factory.fee;
                 }
             }
         }
+        aggregated_amms.extend(amms);
     }
 
     //Save a checkpoint if a path is provided
-
     if let Some(checkpoint_path) = checkpoint_path {
         checkpoint::construct_checkpoint(
             factories,
@@ -114,21 +106,34 @@ pub async fn populate_amms<M: Middleware>(
     middleware: Arc<M>,
 ) -> Result<(), AMMError<M>> {
     if amms_are_congruent(amms) {
+        let multi_progress = MultiProgress::new();
+
         match amms[0] {
             AMM::UniswapV2Pool(_) => {
                 let step = 127; //Max batch size for call
-                for amm_chunk in amms.chunks_mut(step) {
+                let amm_chunks = amms.chunks_mut(step);
+                let progress =
+                    multi_progress.add(init_progress!(amm_chunks.len(), "Populating AMM data v2"));
+                progress.set_position(0);
+                for amm_chunk in amm_chunks {
+                    update_progress_by_one!(progress);
                     uniswap_v2::batch_request::get_amm_data_batch_request(
                         amm_chunk,
                         middleware.clone(),
                     )
                     .await?;
                 }
+                finish_progress!(progress);
             }
 
             AMM::UniswapV3Pool(_) => {
                 let step = 76; //Max batch size for call
-                for amm_chunk in amms.chunks_mut(step) {
+                let amm_chunks = amms.chunks_mut(step);
+                let progress =
+                    multi_progress.add(init_progress!(amm_chunks.len(), "Populating AMM data v3"));
+                progress.set_position(0);
+                for amm_chunk in amm_chunks {
+                    update_progress_by_one!(progress);
                     uniswap_v3::batch_request::get_amm_data_batch_request(
                         amm_chunk,
                         block_number,
@@ -136,13 +141,19 @@ pub async fn populate_amms<M: Middleware>(
                     )
                     .await?;
                 }
+                finish_progress!(progress);
             }
 
             // TODO: Implement batch request
             AMM::ERC4626Vault(_) => {
+                let progress =
+                    multi_progress.add(init_progress!(amms.len(), "Populating ERC4626 vaults"));
+                progress.set_position(0);
                 for amm in amms {
+                    update_progress_by_one!(progress);
                     amm.populate_data(None, middleware.clone()).await?;
                 }
+                finish_progress!(progress);
             }
         }
     } else {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
- Significantly speed up sync speed with JoinSets and Asynchronous processing of `BURN/MINT/SWAP` logs for v3 sync. - Syncing v3 pool tick data properly from a cached checkpoint. 
- Better tracing during sync with progress bars and ETA's.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- Integrate's multi progress bars during sync with ETA's on finality. Packs as much compute as possible into a `JoinSet` when syncing the Mint/Burn/Swap logs on v3 pools. 
- Asynchronous processing of the Mint/Burn/Swap logs by changing `liquidity, liquidity_gross` to `i128` allowing underflow to happen if we hit a burn log before the corresponding mint log. This will yield the same final state when fully synced assuming no overflow on the `i128` (unlikely). 
- Populates v3 pool tick data from the last synced block on the checkpoint to the current chain head. 
## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
