### PR TITLE
add benchmarking tests as in state_changes module

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[target.x86_64-unknown-linux-gnu]
+linker = "clang-15"
+rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,0 @@
-[target.x86_64-unknown-linux-gnu]
-linker = "clang-15"
-rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]

--- a/benches/state_space.rs
+++ b/benches/state_space.rs
@@ -1,5 +1,104 @@
-use criterion as _;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-fn main() {
-    todo!("Implement benchmarks for `state_space` module!");
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("add state changes benchmark", |b| {
+        b.iter(|| bench_funcs::test_add_state_changes(black_box(3)));
+    });
+    c.bench_function("add empty state changes benchmark", |b| {
+        b.iter(|| bench_funcs::test_add_empty_state_changes(black_box(3)));
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);
+
+mod bench_funcs {
+    use std::sync::Arc;
+
+    use alloy::primitives::Address;
+    use amms::{
+        amm::{uniswap_v2::UniswapV2Pool, AMM},
+        state_space::{error::StateChangeError, StateChange, StateChangeCache},
+    };
+
+    use tokio::sync::RwLock;
+
+    /// Duplicated helper method entirely as in `state_space::tests` module
+    /// Reason of duplication: to retain encapsulation
+    async fn add_state_change_to_cache(
+        state_change_cache: Arc<RwLock<StateChangeCache>>,
+        state_change: StateChange,
+    ) -> Result<(), StateChangeError> {
+        let mut state_change_cache = state_change_cache.write().await;
+
+        if state_change_cache.is_full() {
+            state_change_cache.pop_back();
+            state_change_cache
+                .push_front(state_change)
+                .map_err(|_| StateChangeError::CapacityError)?
+        } else {
+            state_change_cache
+                .push_front(state_change)
+                .map_err(|_| StateChangeError::CapacityError)?
+        }
+        Ok(())
+    }
+
+    /// Duplicated method test from `state_change::tests` module
+    pub async fn test_add_state_changes(n: u128) -> eyre::Result<()> {
+        let state_change_cache = Arc::new(RwLock::new(StateChangeCache::new()));
+
+        for i in 0..=n {
+            let new_amm = AMM::UniswapV2Pool(UniswapV2Pool {
+                address: Address::ZERO,
+                reserve_0: i,
+                ..Default::default()
+            });
+
+            add_state_change_to_cache(
+                state_change_cache.clone(),
+                StateChange::new(Some(vec![new_amm]), i as u64),
+            )
+            .await?;
+        }
+
+        let mut state_change_cache = state_change_cache.write().await;
+
+        if let Some(last_state_change) = state_change_cache.pop_front() {
+            if let Some(state_changes) = last_state_change.state_change() {
+                assert_eq!(state_changes.len(), 1);
+
+                if let AMM::UniswapV2Pool(pool) = &state_changes[0] {
+                    assert_eq!(pool.reserve_0, n);
+                } else {
+                    panic!("Unexpected AMM variant")
+                }
+            } else {
+                panic!("State changes not found")
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Duplicated method test from `state_change::tests` module
+    pub async fn test_add_empty_state_changes(n: u64) -> eyre::Result<()> {
+        let last_synced_block = 0;
+        let chain_head_block_number = n;
+
+        let state_change_cache = Arc::new(RwLock::new(StateChangeCache::new()));
+
+        for block_number in last_synced_block..=chain_head_block_number {
+            add_state_change_to_cache(
+                state_change_cache.clone(),
+                StateChange::new(None, block_number),
+            )
+            .await?;
+        }
+
+        let state_change_cache_length = state_change_cache.read().await.len();
+        assert_eq!(state_change_cache_length, 101);
+
+        Ok(())
+    }
 }

--- a/benches/state_space.rs
+++ b/benches/state_space.rs
@@ -2,103 +2,12 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("add state changes benchmark", |b| {
-        b.iter(|| bench_funcs::test_add_state_changes(black_box(3)));
+        b.iter(|| amms::state_space::test_utils::test_add_state_changes(black_box(3)));
     });
     c.bench_function("add empty state changes benchmark", |b| {
-        b.iter(|| bench_funcs::test_add_empty_state_changes(black_box(3)));
+        b.iter(|| amms::state_space::test_utils::test_add_empty_state_changes(black_box(3)));
     });
 }
 
 criterion_group!(benches, criterion_benchmark);
 criterion_main!(benches);
-
-mod bench_funcs {
-    use std::sync::Arc;
-
-    use alloy::primitives::Address;
-    use amms::{
-        amm::{uniswap_v2::UniswapV2Pool, AMM},
-        state_space::{error::StateChangeError, StateChange, StateChangeCache},
-    };
-
-    use tokio::sync::RwLock;
-
-    /// Duplicated helper method entirely as in `state_space::tests` module
-    /// Reason of duplication: to retain encapsulation
-    async fn add_state_change_to_cache(
-        state_change_cache: Arc<RwLock<StateChangeCache>>,
-        state_change: StateChange,
-    ) -> Result<(), StateChangeError> {
-        let mut state_change_cache = state_change_cache.write().await;
-
-        if state_change_cache.is_full() {
-            state_change_cache.pop_back();
-            state_change_cache
-                .push_front(state_change)
-                .map_err(|_| StateChangeError::CapacityError)?
-        } else {
-            state_change_cache
-                .push_front(state_change)
-                .map_err(|_| StateChangeError::CapacityError)?
-        }
-        Ok(())
-    }
-
-    /// Duplicated method test from `state_change::tests` module
-    pub async fn test_add_state_changes(n: u128) -> eyre::Result<()> {
-        let state_change_cache = Arc::new(RwLock::new(StateChangeCache::new()));
-
-        for i in 0..=n {
-            let new_amm = AMM::UniswapV2Pool(UniswapV2Pool {
-                address: Address::ZERO,
-                reserve_0: i,
-                ..Default::default()
-            });
-
-            add_state_change_to_cache(
-                state_change_cache.clone(),
-                StateChange::new(Some(vec![new_amm]), i as u64),
-            )
-            .await?;
-        }
-
-        let mut state_change_cache = state_change_cache.write().await;
-
-        if let Some(last_state_change) = state_change_cache.pop_front() {
-            if let Some(state_changes) = last_state_change.state_change() {
-                assert_eq!(state_changes.len(), 1);
-
-                if let AMM::UniswapV2Pool(pool) = &state_changes[0] {
-                    assert_eq!(pool.reserve_0, n);
-                } else {
-                    panic!("Unexpected AMM variant")
-                }
-            } else {
-                panic!("State changes not found")
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Duplicated method test from `state_change::tests` module
-    pub async fn test_add_empty_state_changes(n: u64) -> eyre::Result<()> {
-        let last_synced_block = 0;
-        let chain_head_block_number = n;
-
-        let state_change_cache = Arc::new(RwLock::new(StateChangeCache::new()));
-
-        for block_number in last_synced_block..=chain_head_block_number {
-            add_state_change_to_cache(
-                state_change_cache.clone(),
-                StateChange::new(None, block_number),
-            )
-            .await?;
-        }
-
-        let state_change_cache_length = state_change_cache.read().await.len();
-        assert_eq!(state_change_cache_length, 101);
-
-        Ok(())
-    }
-}

--- a/src/state_space/mod.rs
+++ b/src/state_space/mod.rs
@@ -294,6 +294,10 @@ impl StateChange {
             state_change,
         }
     }
+
+    pub fn state_change(&self) -> Option<&Vec<AMM>> {
+        self.state_change.as_ref()
+    }
 }
 
 /// Unwinds the state changes cache for every block from the most recent state change cache back to the block to unwind -1.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

In benches module there was a "TODO" to add state change benchmarking tests, which I did.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Simple benchmarking tests added as in `state_change::tests` module.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes

### Bench Output

Here's the results on my machine on `cargo bench` call:

```rust
test result: ok. 0 passed; 0 failed; 30 ignored; 0 measured; 0 filtered out; finished in 0.00s

Running benches/state_space.rs (target/release/deps/state_space-eb8fcd7e36391f42)
Gnuplot not found, using plotters backend
add state changes benchmark
                        time:   [116.82 ns 116.88 ns 116.94 ns]
                        change: [-0.2926% -0.1940% -0.0996%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

add empty state changes benchmark
                        time:   [96.076 ns 96.159 ns 96.270 ns]
                        change: [-0.5076% -0.3311% -0.1669%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe

```