### PR TITLE
Implement Hash, Eq and PartialEq for `AMM` and `Factory` 

### DIFF
--- a/src/amm/factory.rs
+++ b/src/amm/factory.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::{
+    hash::{Hash, Hasher},
+    sync::Arc,
+};
 
 use alloy::{
     network::Network,
@@ -154,6 +157,20 @@ macro_rules! factory {
                 }
             }
         }
+
+        impl Hash for Factory {
+            fn hash<H: Hasher>(&self, state: &mut H) {
+                self.address().hash(state);
+            }
+        }
+
+        impl PartialEq for Factory {
+            fn eq(&self, other: &Self) -> bool {
+                self.address() == other.address()
+            }
+        }
+
+        impl Eq for Factory {}
     };
 }
 

--- a/src/amm/mod.rs
+++ b/src/amm/mod.rs
@@ -4,7 +4,10 @@ pub mod factory;
 pub mod uniswap_v2;
 pub mod uniswap_v3;
 
-use std::sync::Arc;
+use std::{
+    hash::{Hash, Hasher},
+    sync::Arc,
+};
 
 use alloy::{
     network::Network,
@@ -167,6 +170,20 @@ macro_rules! amm {
                 }
             }
         }
+
+        impl Hash for AMM {
+            fn hash<H: Hasher>(&self, state: &mut H) {
+                self.address().hash(state);
+            }
+        }
+
+        impl PartialEq for AMM {
+            fn eq(&self, other: &Self) -> bool {
+                self.address() == other.address()
+            }
+        }
+
+        impl Eq for AMM {}
     };
 }
 


### PR DESCRIPTION
Problem:

Now, enum AMM (and Factory) compare be compared nor inserted into a HashMap. This is a bit inconvenient.

Solution:

I offer to implement Hash, Eq and PartialEq for AMM and Factory macros.
Moreover, I think it will be sufficient (to save up compute time) to just use Addresses for the comparison as they are unique Hashes a priori. 


P.S. Feel free to suggest a better idea. Always open for discussion :)

