### PR TITLE
fix panic: attempt to subtract with overflow

### DIFF
--- a/src/amm/uniswap_v3/mod.rs
+++ b/src/amm/uniswap_v3/mod.rs
@@ -859,7 +859,7 @@ impl UniswapV3Pool {
             //if the tick is between the tick lower and tick upper, update the liquidity between the ticks
             if self.tick > tick_lower && self.tick < tick_upper {
                 self.liquidity = if liquidity_delta < 0 {
-                    self.liquidity - ((-liquidity_delta) as u128)
+                    self.liquidity.checked_sub((-liquidity_delta) as u128).unwrap_or(0)
                 } else {
                     self.liquidity + (liquidity_delta as u128)
                 }
@@ -907,7 +907,7 @@ impl UniswapV3Pool {
         let liquidity_gross_before = info.liquidity_gross;
 
         let liquidity_gross_after = if liquidity_delta < 0 {
-            liquidity_gross_before - ((-liquidity_delta) as u128)
+            liquidity_gross_before.checked_sub((-liquidity_delta) as u128).unwrap_or(0)
         } else {
             liquidity_gross_before + (liquidity_delta as u128)
         };


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

```
cargo run --example sync-amms
2024-08-25T01:47:36.740997Z  INFO amms::sync: Syncing AMMs step=500 factories=[UniswapV2Factory(UniswapV2Factory { address: 0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f, creation_block: 2638438, fee: 300 }), UniswapV2Factory(UniswapV2Factory { address: 0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac, creation_block: 10794229, fee: 300 }), UniswapV3Factory(UniswapV3Factory { address: 0x1f98431c8ad98523631ae4a59f267346ea31f984, creation_block: 185 })]
2024-08-25T01:47:36.741363Z  INFO amms::sync: Getting all AMMs from factory factory=UniswapV2Factory(UniswapV2Factory { address: 0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac, creation_block: 10794229, fee: 300 })
2024-08-25T01:47:36.741362Z  INFO amms::sync: Getting all AMMs from factory factory=UniswapV2Factory(UniswapV2Factory { address: 0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f, creation_block: 2638438, fee: 300 })
2024-08-25T01:47:36.741385Z  INFO amms::sync: Getting all AMMs from factory factory=UniswapV3Factory(UniswapV3Factory { address: 0x1f98431c8ad98523631ae4a59f267346ea31f984, creation_block: 185 })
2024-08-25T01:47:43.330665Z  INFO amms::sync: Populating AMMs from factory factory=UniswapV2Factory(UniswapV2Factory { address: 0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac, creation_block: 10794229, fee: 300 })
2024-08-25T01:48:35.353262Z  INFO amms::sync: Populating AMMs from factory factory=UniswapV2Factory(UniswapV2Factory { address: 0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f, creation_block: 2638438, fee: 300 })
thread 'tokio-runtime-worker' panicked at crates/amms-rs-main/src/amm/uniswap_v3/mod.rs:910:13:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


2024-08-25T01:51:17.046158Z  INFO amms::sync: Syncing AMMs step=500 factories=[UniswapV2Factory(UniswapV2Factory { address: 0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f, creation_block: 2638438, fee: 300 }), UniswapV2Factory(UniswapV2Factory { address: 0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac, creation_block: 10794229, fee: 300 }), UniswapV3Factory(UniswapV3Factory { address: 0x1f98431c8ad98523631ae4a59f267346ea31f984, creation_block: 185 })]
2024-08-25T01:51:17.046658Z  INFO amms::sync: Getting all AMMs from factory factory=UniswapV2Factory(UniswapV2Factory { address: 0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f, creation_block: 2638438, fee: 300 })
2024-08-25T01:51:17.046668Z  INFO amms::sync: Getting all AMMs from factory factory=UniswapV2Factory(UniswapV2Factory { address: 0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac, creation_block: 10794229, fee: 300 })
2024-08-25T01:51:17.046684Z  INFO amms::sync: Getting all AMMs from factory factory=UniswapV3Factory(UniswapV3Factory { address: 0x1f98431c8ad98523631ae4a59f267346ea31f984, creation_block: 185 })
2024-08-25T01:51:21.282256Z  INFO amms::sync: Populating AMMs from factory factory=UniswapV2Factory(UniswapV2Factory { address: 0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac, creation_block: 10794229, fee: 300 })
2024-08-25T01:52:07.841715Z  INFO amms::sync: Populating AMMs from factory factory=UniswapV2Factory(UniswapV2Factory { address: 0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f, creation_block: 2638438, fee: 300 })
thread 'tokio-runtime-worker' panicked at crates/amms-rs-main/src/amm/uniswap_v3/mod.rs:862:21:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2024-08-25T01:53:07.135118Z  INFO alloy_pubsub::service: Pubsub service request channel closed. Shutting down.


```

## Solution

use `checked_sub`