### PR TITLE
Fix compilation with `--no-default-features`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,7 @@ alloy = { version = "0.2", features = [
 ] }
 
 [features]
-default = ["filters", "state-space"]
-filters = []
+default = ["state-space"]
 state-space = ["arraydeque"]
 # TODO: Uncomment this when artemis is published as a crate
 # artemis = ["artemis-core"] 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 pub mod amm;
 pub mod discovery;
 pub mod errors;
-#[cfg(feature = "filters")]
 pub mod filters;
 #[cfg(feature = "state-space")]
 pub mod state_space;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 pub mod amm;
 pub mod discovery;
 pub mod errors;
+#[cfg(feature = "filters")]
 pub mod filters;
+#[cfg(feature = "state-space")]
 pub mod state_space;
 pub mod sync;


### PR DESCRIPTION
This PR gates the state space mod behind the `state-space` feature flag. Additionally, the `filters` feature flag was removed and filters are now included by default.
