### PR TITLE
feat(balancer): Add `BalancerV2Factory` to `discovery` mod

### DIFF
--- a/src/discovery/factory.rs
+++ b/src/discovery/factory.rs
@@ -11,7 +11,7 @@ use alloy::{
 
 use crate::{
     amm::{
-        factory::Factory, uniswap_v2::factory::IUniswapV2Factory,
+        balancer_v2::factory::IBFactory, factory::Factory, uniswap_v2::factory::IUniswapV2Factory,
         uniswap_v3::factory::IUniswapV3Factory,
     },
     errors::AMMError,
@@ -20,6 +20,7 @@ use crate::{
 pub enum DiscoverableFactory {
     UniswapV2Factory,
     UniswapV3Factory,
+    BalancerV2Factory,
 }
 
 impl DiscoverableFactory {
@@ -27,6 +28,7 @@ impl DiscoverableFactory {
         match self {
             DiscoverableFactory::UniswapV2Factory => IUniswapV2Factory::PairCreated::SIGNATURE_HASH,
             DiscoverableFactory::UniswapV3Factory => IUniswapV3Factory::PoolCreated::SIGNATURE_HASH,
+            DiscoverableFactory::BalancerV2Factory => IBFactory::LOG_NEW_POOL::SIGNATURE_HASH,
         }
     }
 }
@@ -90,6 +92,11 @@ where
                     Factory::UniswapV3Factory(uniswap_v3_factory) => {
                         uniswap_v3_factory.address = log.address();
                         uniswap_v3_factory.creation_block =
+                            log.block_number.ok_or(AMMError::BlockNumberNotFound)?;
+                    }
+                    Factory::BalancerV2Factory(balancer_v2_factory) => {
+                        balancer_v2_factory.address = log.address();
+                        balancer_v2_factory.creation_block =
                             log.block_number.ok_or(AMMError::BlockNumberNotFound)?;
                     }
                 }

--- a/src/filters/value.rs
+++ b/src/filters/value.rs
@@ -10,7 +10,11 @@ use alloy::{
 };
 
 use crate::{
-    amm::{factory::AutomatedMarketMakerFactory, factory::Factory, AutomatedMarketMaker, AMM},
+    amm::{
+        balancer_v2::factory::BalancerV2Factory,
+        factory::{AutomatedMarketMakerFactory, Factory},
+        AutomatedMarketMaker, AMM,
+    },
     errors::AMMError,
 };
 
@@ -175,6 +179,7 @@ where
         .map(|d| match d {
             Factory::UniswapV2Factory(_) => false,
             Factory::UniswapV3Factory(_) => true,
+            Factory::BalancerV2Factory(_) => false,
         })
         .collect::<Vec<bool>>();
 


### PR DESCRIPTION
Addresses #196

This PR adds `BalancerV2Factory` to discoverable factories.

```rust
pub enum DiscoverableFactory {
    UniswapV2Factory,
    UniswapV3Factory,
    BalancerV2Factory,
}

impl DiscoverableFactory {
    pub fn discovery_event_signature(&self) -> B256 {
        match self {
            DiscoverableFactory::UniswapV2Factory => IUniswapV2Factory::PairCreated::SIGNATURE_HASH,
            DiscoverableFactory::UniswapV3Factory => IUniswapV3Factory::PoolCreated::SIGNATURE_HASH,
            DiscoverableFactory::BalancerV2Factory => IBFactory::LOG_NEW_POOL::SIGNATURE_HASH,
        }
    }
}

```