### PR TITLE
Chore/alloy 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.38", default-features = false }
 tracing = "0.1"
-uniswap_v3_math = "0.5.1"
-alloy = { version = "0.2", features = [
+uniswap_v3_math = { git = "https://github.com/0xKitsune/uniswap-v3-math.git" }
+alloy = { version = "0.3", features = [
     "contract",
     "network",
     "provider-ws",
@@ -49,7 +49,7 @@ criterion = "0.5"
 tokio = { version = "1.38", default-features = false, features = [
     "rt-multi-thread",
 ] }
-alloy = { version = "0.2", features = ["rpc-client"] }
+alloy = { version = "0.3", features = ["rpc-client"] }
 
 [[bench]]
 name = "state_space"

--- a/src/amm/uniswap_v2/mod.rs
+++ b/src/amm/uniswap_v2/mod.rs
@@ -96,10 +96,16 @@ impl AutomatedMarketMaker for UniswapV2Pool {
 
         if event_signature == IUniswapV2Pair::Sync::SIGNATURE_HASH {
             let sync_event = IUniswapV2Pair::Sync::decode_log(log.as_ref(), true)?;
-            tracing::info!(reserve_0 = sync_event.reserve0, reserve_1 = sync_event.reserve1, address = ?self.address, "UniswapV2 sync event");
 
-            self.reserve_0 = sync_event.reserve0;
-            self.reserve_1 = sync_event.reserve1;
+            let (reserve_0, reserve_1) = (
+                sync_event.reserve0.to::<u128>(),
+                sync_event.reserve1.to::<u128>(),
+            );
+
+            tracing::info!(reserve_0, reserve_1, address = ?self.address, "UniswapV2 sync event");
+
+            self.reserve_0 = reserve_0;
+            self.reserve_1 = reserve_1;
 
             Ok(())
         } else {
@@ -321,6 +327,8 @@ impl UniswapV2Pool {
             Ok(result) => result,
             Err(contract_error) => return Err(AMMError::ContractError(contract_error)),
         };
+
+        let (reserve_0, reserve_1) = (reserve_0.to::<u128>(), reserve_1.to::<u128>());
 
         tracing::trace!(reserve_0, reserve_1);
 

--- a/src/amm/uniswap_v3/batch_request/mod.rs
+++ b/src/amm/uniswap_v3/batch_request/mod.rs
@@ -3,6 +3,7 @@ use std::{sync::Arc, vec};
 use alloy::{
     dyn_abi::{DynSolType, DynSolValue},
     network::Network,
+    primitives::aliases::I24,
     providers::Provider,
     sol,
     transports::Transport,
@@ -123,9 +124,9 @@ where
         provider,
         pool.address,
         zero_for_one,
-        tick_start,
+        I24::unchecked_from(tick_start),
         num_ticks,
-        pool.tick_spacing,
+        I24::unchecked_from(pool.tick_spacing),
     );
     let res = if let Some(block_number) = block_number {
         deployer.block(block_number.into()).call_raw().await?

--- a/src/amm/uniswap_v3/factory.rs
+++ b/src/amm/uniswap_v3/factory.rs
@@ -130,7 +130,7 @@ impl AutomatedMarketMakerFactory for UniswapV3Factory {
             token_b: pool_created_event.token1,
             token_a_decimals: 0,
             token_b_decimals: 0,
-            fee: pool_created_event.fee,
+            fee: pool_created_event.fee.to::<u32>(),
             liquidity: 0,
             sqrt_price: U256::ZERO,
             tick_spacing: 0,

--- a/src/state_space/cache.rs
+++ b/src/state_space/cache.rs
@@ -12,6 +12,12 @@ pub struct StateChangeCache<const CAP: usize> {
     cache: ArrayDeque<StateChange, CAP>,
 }
 
+impl<const CAP: usize> Default for StateChangeCache<CAP> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<const CAP: usize> StateChangeCache<CAP> {
     pub fn new() -> Self {
         StateChangeCache {

--- a/src/state_space/error.rs
+++ b/src/state_space/error.rs
@@ -1,14 +1,45 @@
+use std::fmt;
+
 use crate::errors::{AMMError, ArithmeticError, EventLogError};
 
-use alloy::{primitives::Address, rpc::types::eth::Block, transports::TransportError};
+use alloy::{network::Network, primitives::Address, transports::TransportError};
 
 use arraydeque::CapacityError;
 use thiserror::Error;
 
 use super::StateChange;
 
+// Define newtype wrappers to distinguish between the SendErrors
+#[derive(Debug)]
+pub struct StateChangeSendErrorWrapper(pub tokio::sync::mpsc::error::SendError<Vec<Address>>);
+
+#[derive(Debug)]
+pub struct BlockSendErrorWrapper<N: Network>(
+    pub tokio::sync::mpsc::error::SendError<<N as alloy::providers::Network>::BlockResponse>,
+);
+
+// Implement Display for StateChangeSendErrorWrapper
+impl fmt::Display for StateChangeSendErrorWrapper {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "StateChange send error: {}", self.0)
+    }
+}
+
+// Implement Error for StateChangeSendErrorWrapper
+impl std::error::Error for StateChangeSendErrorWrapper {}
+
+// Implement Display for BlockSendErrorWrapper
+impl<N: Network> fmt::Display for BlockSendErrorWrapper<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Block send error: {}", self.0)
+    }
+}
+
+// Implement Error for BlockSendErrorWrapper
+impl<N: Network> std::error::Error for BlockSendErrorWrapper<N> {}
+
 #[derive(Error, Debug)]
-pub enum StateSpaceError {
+pub enum StateSpaceError<N: Network> {
     #[error(transparent)]
     TransportError(#[from] TransportError),
     #[error(transparent)]
@@ -30,11 +61,11 @@ pub enum StateSpaceError {
     #[error("Block number not found")]
     BlockNumberNotFound,
     #[error(transparent)]
-    StateChangeSendError(#[from] tokio::sync::mpsc::error::SendError<Vec<Address>>),
+    StateChangeSendError(#[from] StateChangeSendErrorWrapper),
     #[error(transparent)]
     CapacityError(#[from] CapacityError<StateChange>),
     #[error(transparent)]
-    BlockSendError(#[from] tokio::sync::mpsc::error::SendError<Block>),
+    BlockSendError(#[from] BlockSendErrorWrapper<N>),
     #[error("Already listening for state changes")]
     AlreadyListeningForStateChanges,
     #[error(transparent)]


### PR DESCRIPTION
Changeset:

1. Alloy bumped to 0.3.
2. StateSpaceError updated to reflect the changes.
3. Type conversions across the repo to keep the same types after the update.


No functionality changed.