### PR TITLE
feat: v2 + v3 factory address tracked for better discovery debugging / analysis

### DIFF
--- a/benches/uniswapv2_simulate.rs
+++ b/benches/uniswapv2_simulate.rs
@@ -15,6 +15,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     let mut pool = UniswapV2Pool {
         address: address!("ddF8390cEd9fAD414b1ca1DD4Fe14F881C2Cfa70"),
+        factory_address: None,
         token_a,
         token_a_decimals: 18,
         token_b: address!("fc0d6cf33e38bce7ca7d89c0e292274031b7157a"),

--- a/examples/filter-value.rs
+++ b/examples/filter-value.rs
@@ -50,7 +50,7 @@ async fn main() -> eyre::Result<()> {
     let usdc = address!("3c499c542cEF5E3811e1192ce70d8cC03d5c3359");
     let usd_weth_pair_address = address!("cd353F79d9FADe311fC3119B841e1f456b54e858");
     let usd_weth_pool = AMM::UniswapV2Pool(
-        UniswapV2Pool::new_from_address(usd_weth_pair_address, 300, provider.clone()).await?,
+        UniswapV2Pool::new_from_address(usd_weth_pair_address, None, 300, provider.clone()).await?,
     );
     let weth_value_in_token_to_weth_pool_threshold = U256::from(100000000000000000_u128); // 10 weth
 

--- a/examples/simulate-swap.rs
+++ b/examples/simulate-swap.rs
@@ -16,7 +16,7 @@ async fn main() -> eyre::Result<()> {
 
     // Initialize the pool
     let pool_address = address!("B4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc"); // WETH/USDC
-    let pool = UniswapV2Pool::new_from_address(pool_address, 300, provider.clone()).await?;
+    let pool = UniswapV2Pool::new_from_address(pool_address, None, 300, provider.clone()).await?;
 
     // Simulate a swap
     let token_in = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");

--- a/examples/swap-calldata.rs
+++ b/examples/swap-calldata.rs
@@ -16,7 +16,7 @@ async fn main() -> eyre::Result<()> {
 
     // Initialize the pool
     let pool_address = address!("B4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc");
-    let pool = UniswapV2Pool::new_from_address(pool_address, 300, provider.clone()).await?;
+    let pool = UniswapV2Pool::new_from_address(pool_address, None, 300, provider.clone()).await?;
 
     // Generate the swap calldata
     let to_address = address!("DecafC0ffee15BadDecafC0ffee15BadDecafC0f");

--- a/src/amm/uniswap_v2/factory.rs
+++ b/src/amm/uniswap_v2/factory.rs
@@ -127,7 +127,7 @@ impl AutomatedMarketMakerFactory for UniswapV2Factory {
     {
         let pair_created_event = IUniswapV2Factory::PairCreated::decode_log(log.as_ref(), true)?;
         Ok(AMM::UniswapV2Pool(
-            UniswapV2Pool::new_from_address(pair_created_event.pair, self.fee, provider).await?,
+            UniswapV2Pool::new_from_address(pair_created_event.pair, log.address(), self.fee, provider).await?,
         ))
     }
 
@@ -136,6 +136,7 @@ impl AutomatedMarketMakerFactory for UniswapV2Factory {
 
         Ok(AMM::UniswapV2Pool(UniswapV2Pool {
             address: pair_created_event.pair,
+            factory_address: log.address(),
             token_a: pair_created_event.token0,
             token_b: pair_created_event.token1,
             token_a_decimals: 0,

--- a/src/amm/uniswap_v2/factory.rs
+++ b/src/amm/uniswap_v2/factory.rs
@@ -127,7 +127,7 @@ impl AutomatedMarketMakerFactory for UniswapV2Factory {
     {
         let pair_created_event = IUniswapV2Factory::PairCreated::decode_log(log.as_ref(), true)?;
         Ok(AMM::UniswapV2Pool(
-            UniswapV2Pool::new_from_address(pair_created_event.pair, log.address(), self.fee, provider).await?,
+            UniswapV2Pool::new_from_address(pair_created_event.pair, Some(log.address()), self.fee, provider).await?,
         ))
     }
 
@@ -136,7 +136,7 @@ impl AutomatedMarketMakerFactory for UniswapV2Factory {
 
         Ok(AMM::UniswapV2Pool(UniswapV2Pool {
             address: pair_created_event.pair,
-            factory_address: log.address(),
+            factory_address: Some(log.address()),
             token_a: pair_created_event.token0,
             token_b: pair_created_event.token1,
             token_a_decimals: 0,

--- a/src/amm/uniswap_v2/mod.rs
+++ b/src/amm/uniswap_v2/mod.rs
@@ -39,6 +39,7 @@ sol! {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct UniswapV2Pool {
     pub address: Address,
+    pub factory_address: Address,
     pub token_a: Address,
     pub token_a_decimals: u8,
     pub token_b: Address,
@@ -187,6 +188,7 @@ impl UniswapV2Pool {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         address: Address,
+        factory_address: Address,
         token_a: Address,
         token_a_decimals: u8,
         token_b: Address,
@@ -197,6 +199,7 @@ impl UniswapV2Pool {
     ) -> UniswapV2Pool {
         UniswapV2Pool {
             address,
+            factory_address,
             token_a,
             token_a_decimals,
             token_b,
@@ -210,6 +213,7 @@ impl UniswapV2Pool {
     /// Creates a new instance of the pool from the pair address, and syncs the pool data.
     pub async fn new_from_address<T, N, P>(
         pair_address: Address,
+        factory_address: Address,
         fee: u32,
         provider: Arc<P>,
     ) -> Result<Self, AMMError>
@@ -220,6 +224,7 @@ impl UniswapV2Pool {
     {
         let mut pool = UniswapV2Pool {
             address: pair_address,
+            factory_address,
             token_a: Address::ZERO,
             token_a_decimals: 0,
             token_b: Address::ZERO,
@@ -256,7 +261,7 @@ impl UniswapV2Pool {
         if event_signature == IUniswapV2Factory::PairCreated::SIGNATURE_HASH {
             let pair_created_event =
                 factory::IUniswapV2Factory::PairCreated::decode_log(log.as_ref(), true)?;
-            UniswapV2Pool::new_from_address(pair_created_event.pair, fee, provider).await
+            UniswapV2Pool::new_from_address(pair_created_event.pair, log.address(), fee, provider).await
         } else {
             Err(EventLogError::InvalidEventSignature)?
         }
@@ -274,6 +279,7 @@ impl UniswapV2Pool {
 
             Ok(UniswapV2Pool {
                 address: pair_created_event.pair,
+                factory_address: log.address(),
                 token_a: pair_created_event.token0,
                 token_b: pair_created_event.token1,
                 token_a_decimals: 0,
@@ -583,6 +589,7 @@ mod tests {
 
         let pool = UniswapV2Pool::new_from_address(
             address!("B4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc"),
+            address!("5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f"),
             300,
             provider.clone(),
         )
@@ -592,6 +599,10 @@ mod tests {
         assert_eq!(
             pool.address,
             address!("B4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc")
+        );
+        assert_eq!(
+            pool.factory_address,
+            address!("5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f")
         );
         assert_eq!(
             pool.token_a,
@@ -640,6 +651,7 @@ mod tests {
         let token_b = address!("8f18dc399594b451eda8c5da02d0563c0b2d0f16");
         let x = UniswapV2Pool {
             address: address!("652a7b75c229850714d4a11e856052aac3e9b065"),
+            factory_address: address!("5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f"),
             token_a,
             token_a_decimals: 18,
             token_b,

--- a/src/amm/uniswap_v2/mod.rs
+++ b/src/amm/uniswap_v2/mod.rs
@@ -39,7 +39,8 @@ sol! {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct UniswapV2Pool {
     pub address: Address,
-    pub factory_address: Address,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub factory_address: Option<Address>,
     pub token_a: Address,
     pub token_a_decimals: u8,
     pub token_b: Address,
@@ -199,7 +200,7 @@ impl UniswapV2Pool {
     ) -> UniswapV2Pool {
         UniswapV2Pool {
             address,
-            factory_address,
+            factory_address: Some(factory_address),
             token_a,
             token_a_decimals,
             token_b,
@@ -213,7 +214,7 @@ impl UniswapV2Pool {
     /// Creates a new instance of the pool from the pair address, and syncs the pool data.
     pub async fn new_from_address<T, N, P>(
         pair_address: Address,
-        factory_address: Address,
+        factory_address: Option<Address>,
         fee: u32,
         provider: Arc<P>,
     ) -> Result<Self, AMMError>
@@ -261,7 +262,7 @@ impl UniswapV2Pool {
         if event_signature == IUniswapV2Factory::PairCreated::SIGNATURE_HASH {
             let pair_created_event =
                 factory::IUniswapV2Factory::PairCreated::decode_log(log.as_ref(), true)?;
-            UniswapV2Pool::new_from_address(pair_created_event.pair, log.address(), fee, provider).await
+            UniswapV2Pool::new_from_address(pair_created_event.pair, Some(log.address()), fee, provider).await
         } else {
             Err(EventLogError::InvalidEventSignature)?
         }
@@ -279,7 +280,7 @@ impl UniswapV2Pool {
 
             Ok(UniswapV2Pool {
                 address: pair_created_event.pair,
-                factory_address: log.address(),
+                factory_address: Some(log.address()),
                 token_a: pair_created_event.token0,
                 token_b: pair_created_event.token1,
                 token_a_decimals: 0,
@@ -589,7 +590,7 @@ mod tests {
 
         let pool = UniswapV2Pool::new_from_address(
             address!("B4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc"),
-            address!("5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f"),
+            Some(address!("5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f")),
             300,
             provider.clone(),
         )
@@ -602,7 +603,7 @@ mod tests {
         );
         assert_eq!(
             pool.factory_address,
-            address!("5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f")
+            Some(address!("5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f"))
         );
         assert_eq!(
             pool.token_a,
@@ -651,7 +652,7 @@ mod tests {
         let token_b = address!("8f18dc399594b451eda8c5da02d0563c0b2d0f16");
         let x = UniswapV2Pool {
             address: address!("652a7b75c229850714d4a11e856052aac3e9b065"),
-            factory_address: address!("5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f"),
+            factory_address: Some(address!("5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f")),
             token_a,
             token_a_decimals: 18,
             token_b,

--- a/src/amm/uniswap_v3/factory.rs
+++ b/src/amm/uniswap_v3/factory.rs
@@ -65,7 +65,7 @@ impl AutomatedMarketMakerFactory for UniswapV3Factory {
         if let Some(block_number) = log.block_number {
             let pool_created_filter = IUniswapV3Factory::PoolCreated::decode_log(&log.inner, true)?;
             Ok(AMM::UniswapV3Pool(
-                UniswapV3Pool::new_from_address(pool_created_filter.pool, block_number, provider)
+                UniswapV3Pool::new_from_address(pool_created_filter.pool, Some(log.address()), block_number, provider)
                     .await?,
             ))
         } else {
@@ -126,6 +126,7 @@ impl AutomatedMarketMakerFactory for UniswapV3Factory {
 
         Ok(AMM::UniswapV3Pool(UniswapV3Pool {
             address: pool_created_event.pool,
+            factory_address: Some(log.address()),
             token_a: pool_created_event.token0,
             token_b: pool_created_event.token1,
             token_a_decimals: 0,

--- a/src/amm/uniswap_v3/mod.rs
+++ b/src/amm/uniswap_v3/mod.rs
@@ -51,7 +51,8 @@ sol! {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct UniswapV3Pool {
     pub address: Address,
-    pub factory_address: Address,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub factory_address: Option<Address>,
     pub token_a: Address,
     pub token_a_decimals: u8,
     pub token_b: Address,
@@ -455,7 +456,7 @@ impl UniswapV3Pool {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         address: Address,
-        factory_address: Address,
+        factory_address: Option<Address>,
         token_a: Address,
         token_a_decimals: u8,
         token_b: Address,
@@ -490,7 +491,7 @@ impl UniswapV3Pool {
     /// This function will populate all pool data.
     pub async fn new_from_address<T, N, P>(
         pair_address: Address,
-        factory_address: Address,
+        factory_address: Option<Address>,
         creation_block: u64,
         provider: Arc<P>,
     ) -> Result<Self, AMMError>
@@ -548,7 +549,7 @@ impl UniswapV3Pool {
                 let pool_created_event =
                     IUniswapV3Factory::PoolCreated::decode_log(&log.inner, true)?;
 
-                UniswapV3Pool::new_from_address(pool_created_event.pool, log.address(), block_number, provider)
+                UniswapV3Pool::new_from_address(pool_created_event.pool, Some(log.address()), block_number, provider)
                     .await
             } else {
                 Err(EventLogError::LogBlockNumberNotFound)?
@@ -569,7 +570,7 @@ impl UniswapV3Pool {
 
             Ok(UniswapV3Pool {
                 address: pool_created_event.pool,
-                factory_address: log.address(),
+                factory_address: Some(log.address()),
                 token_a: pool_created_event.token0,
                 token_b: pool_created_event.token1,
                 token_a_decimals: 0,
@@ -1865,7 +1866,7 @@ mod test {
 
         let pool = UniswapV3Pool::new_from_address(
             address!("88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640"),
-            address!("1F98431c8aD98523631AE4a59f267346ea31F984"),
+            Some(address!("1F98431c8aD98523631AE4a59f267346ea31F984")),
             12369620,
             provider.clone(),
         )


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

A `factory_address` field in V2 and V3 proves helpful in understand what pools from which factories are discovered via the `PairCreated` / `PoolCreated` event. This can also prove helpful in analysing the contributions from which V2-like / V3-like protocols in pathing e.g 0x-style.

<img width="878" alt="image" src="https://github.com/user-attachments/assets/28987499-1cbb-468b-8e80-1878718e59b9">

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Added `factory_address` to `UniswapV2Pool` and `UniswapV3Pool`
- Updated constructors
- Updated tests

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Breaking changes
