### PR TITLE
feat(amms): Add `Token` type instead of specifying `token_address` and `token_decimals` directly on pool.

### DIFF
--- a/src/amms/mod.rs
+++ b/src/amms/mod.rs
@@ -22,6 +22,25 @@ sol! {
     "contracts/out/GetTokenDecimalsBatchRequest.sol/GetTokenDecimalsBatchRequest.json",
 }
 
+pub struct Token {
+    address: Address,
+    decimals: u8,
+}
+
+impl Token {
+    pub fn new(address: Address, decimals: u8) -> Self {
+        Self { address, decimals }
+    }
+
+    pub fn address(&self) -> Address {
+        self.address
+    }
+
+    pub fn decimals(&self) -> u8 {
+        self.decimals
+    }
+}
+
 /// Fetches the decimal precision for a list of ERC-20 tokens.
 ///
 /// # Returns

--- a/src/amms/mod.rs
+++ b/src/amms/mod.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    hash::{Hash, Hasher},
+    sync::Arc,
+};
 
 use alloy::{
     dyn_abi::DynSolType, network::Network, primitives::Address, providers::Provider, sol,
@@ -23,7 +27,7 @@ sol! {
     "contracts/out/GetTokenDecimalsBatchRequest.sol/GetTokenDecimalsBatchRequest.json",
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Token {
     address: Address,
     decimals: u8,
@@ -41,6 +45,12 @@ impl Token {
 
     pub const fn decimals(&self) -> u8 {
         self.decimals
+    }
+}
+
+impl Hash for Token {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.address.hash(state);
     }
 }
 

--- a/src/amms/mod.rs
+++ b/src/amms/mod.rs
@@ -5,6 +5,7 @@ use alloy::{
     transports::Transport,
 };
 use futures::{stream::FuturesUnordered, StreamExt};
+use serde::{Deserialize, Serialize};
 
 pub mod amm;
 pub mod balancer;
@@ -22,21 +23,23 @@ sol! {
     "contracts/out/GetTokenDecimalsBatchRequest.sol/GetTokenDecimalsBatchRequest.json",
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Token {
     address: Address,
     decimals: u8,
+    // TODO: add optional tax
 }
 
 impl Token {
-    pub fn new(address: Address, decimals: u8) -> Self {
+    pub const fn new(address: Address, decimals: u8) -> Self {
         Self { address, decimals }
     }
 
-    pub fn address(&self) -> Address {
+    pub const fn address(&self) -> Address {
         self.address
     }
 
-    pub fn decimals(&self) -> u8 {
+    pub const fn decimals(&self) -> u8 {
         self.decimals
     }
 }


### PR DESCRIPTION
This PR introduces the `Token` type which encapsulates token addresses and decimals into a single struct. This change enforces that tokens have the same interface across all pools. In the future, this type could also optionally handle token tax logic.


Before:
```rust
pub struct UniswapV2Pool {
    pub address: Address,
    pub token_a: Address,
    pub token_a_decimals: u8,
    pub token_b: Address,
    pub token_b_decimals: u8,
    pub reserve_0: u128,
    pub reserve_1: u128,
    pub fee: usize,
}
```

After:
```rust
pub struct UniswapV2Pool {
    pub address: Address,
    pub token_a: Token,
    pub token_b: Token,
    pub reserve_0: u128,
    pub reserve_1: u128,
    pub fee: usize,
}
```



