### PR TITLE
refactor prices+fees

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ alloy = { version = "0.9", features = [
 alloy-json-rpc = { version = "0.5" }
 
 # tracing
-eyre = "0.6"
 tracing = "0.1"
 
 # async
@@ -47,7 +46,6 @@ lazy_static = "1.5"
 num-bigfloat = "1.7"
 regex = "1.10"
 thiserror = "1.0"
-rug = "1.24.1"
 derive_more = "1.0.0"
 governor = "0.7.0"
 itertools = "0.13.0"
@@ -57,6 +55,7 @@ async-stream = "0.3.6"
 
 
 [dev-dependencies]
+float-cmp = "0.10.0"
 rand = "0.8.5"
 tracing-subscriber = "0.3"
 criterion = "0.5"
@@ -64,21 +63,13 @@ tokio = { version = "1.42", default-features = false, features = [
     "rt-multi-thread",
 ] }
 alloy = { version = "0.9", features = ["rpc-client"] }
-
-[build-dependencies]
-
+eyre = "0.6"
 
 [profile.release]
 opt-level = 3
 lto = true
 codegen-units = 1
 panic = "abort"
-
-[profile.dev]
-opt-level = 3
-lto = true
-codegen-units = 1
-debug = "full"
 
 
 [[bench]]

--- a/benches/uniswap_v2.rs
+++ b/benches/uniswap_v2.rs
@@ -14,7 +14,7 @@ fn simulate_swap(c: &mut Criterion) {
         token_b_decimals: 18,
         reserve_0: 20_000_000_u128,
         reserve_1: 20_000_000_u128,
-        fee: 300,
+        fee: 3000,
         ..Default::default()
     };
 

--- a/contracts/src/Balancer/GetBalancerPoolDataBatchRequest.sol
+++ b/contracts/src/Balancer/GetBalancerPoolDataBatchRequest.sol
@@ -22,7 +22,7 @@ contract GetBalancerPoolDataBatchRequest {
         uint8[] decimals;
         uint256[] liquidity;
         uint256[] weights;
-        uint32 fee;
+        uint64 fee;
     }
 
     constructor(address[] memory pools) {
@@ -62,7 +62,7 @@ contract GetBalancerPoolDataBatchRequest {
             }
 
             // Grab the swap fee
-            poolData.fee = uint32(IBPool(poolAddress).getSwapFee());
+            poolData.fee = uint64(IBPool(poolAddress).getSwapFee());
             poolData.tokens = tokens;
             poolData.decimals = decimals;
             poolData.liquidity = liquidity;

--- a/examples/filters.rs
+++ b/examples/filters.rs
@@ -28,7 +28,7 @@ async fn main() -> eyre::Result<()> {
         // UniswapV2
         UniswapV2Factory::new(
             address!("5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f"),
-            300,
+            3000,
             10000835,
         )
         .into(),

--- a/examples/state_space_builder.rs
+++ b/examples/state_space_builder.rs
@@ -38,7 +38,7 @@ async fn main() -> eyre::Result<()> {
         // UniswapV2
         UniswapV2Factory::new(
             address!("5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f"),
-            300,
+            3000,
             10000835,
         )
         .into(),
@@ -62,7 +62,7 @@ async fn main() -> eyre::Result<()> {
     need to track a handful of specific pools.
     */
     let amms = vec![
-        UniswapV2Pool::new(address!("B4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc"), 300).into(),
+        UniswapV2Pool::new(address!("B4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc"), 3000).into(),
         UniswapV3Pool::new(address!("88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640")).into(),
     ];
 
@@ -81,7 +81,6 @@ async fn main() -> eyre::Result<()> {
     let amms = vec![ERC4626Vault::new(address!("163538E22F4d38c1eb21B79939f3d2ee274198Ff")).into()];
 
     let _state_space_manager = StateSpaceBuilder::new(provider.clone())
-        .with_factories(factories)
         .with_amms(amms)
         .sync()
         .await?;

--- a/examples/swap_calldata.rs
+++ b/examples/swap_calldata.rs
@@ -18,7 +18,7 @@ async fn main() -> eyre::Result<()> {
 
     let provider = Arc::new(ProviderBuilder::new().on_client(client));
 
-    let pool = UniswapV2Pool::new(address!("B4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc"), 300)
+    let pool = UniswapV2Pool::new(address!("B4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc"), 3000)
         .init(BlockId::latest(), provider)
         .await?;
 

--- a/examples/sync_macro.rs
+++ b/examples/sync_macro.rs
@@ -33,7 +33,7 @@ async fn main() -> eyre::Result<()> {
         // UniswapV2
         UniswapV2Factory::new(
             address!("5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f"),
-            300,
+            3000,
             10000835,
         )
         .into(),

--- a/src/amms/amm.rs
+++ b/src/amms/amm.rs
@@ -10,7 +10,6 @@ use alloy::{
     rpc::types::Log,
     transports::Transport,
 };
-use eyre::Result;
 use serde::{Deserialize, Serialize};
 use std::{
     hash::{Hash, Hasher},
@@ -31,7 +30,8 @@ pub trait AutomatedMarketMaker {
     /// Returns a list of token addresses used in the AMM
     fn tokens(&self) -> Vec<Address>;
 
-    /// Calculates the price of `base_token` in terms of `quote_token`
+    /// Calculates the price of `base_token` in terms of `quote_token` with fee included
+    /// The result should be precise down to a few bits
     fn calculate_price(&self, base_token: Address, quote_token: Address) -> Result<f64, AMMError>;
 
     /// Simulate a swap

--- a/src/amms/consts.rs
+++ b/src/amms/consts.rs
@@ -20,6 +20,10 @@ pub const U256_4: U256 = U256::from_limbs([4, 0, 0, 0]);
 pub const U256_2: U256 = U256::from_limbs([2, 0, 0, 0]);
 pub const U256_1: U256 = U256::from_limbs([1, 0, 0, 0]);
 
+pub const U256_FEE_ONE: U256 = U256::from_limbs([1_000_000, 0, 0, 0]);
+pub const U32_FEE_ONE: u32 = 1_000_000;
+pub const F64_FEE_ONE: f64 = 1e6;
+
 // Uniswap V3 specific
 pub const POPULATE_TICK_DATA_STEP: u64 = 100000;
 pub const Q128: U256 = U256::from_limbs([0, 0, 1, 0]);
@@ -27,6 +31,8 @@ pub const Q224: U256 = U256::from_limbs([0, 0, 0, 4294967296]);
 
 // Balancer V2 specific
 pub const BONE: U256 = U256::from_limbs([0xDE0B6B3A7640000, 0, 0, 0]);
+pub const F64_BONE: f64 = 1e18;
+pub const U64_BONE: u64 = 0xDE0B6B3A7640000;
 
 // Others
 pub const U128_0X10000000000000000: u128 = 18446744073709551616;
@@ -38,6 +44,16 @@ pub const U256_0XFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF: U256 = U256::
 ]);
 pub const U256_0XFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF: U256 =
     U256::from_limbs([18446744073709551615, 18446744073709551615, 0, 0]);
+pub const U256_0X1FFFFFFFFFFFFF: U256 =
+    U256::from_limbs([9007199254740991, 0, 0, 0]); // 2^53 - 1
+pub const U256_0X3FFFFFFFFFFFFF: U256 =
+    U256::from_limbs([18014398509481983, 0, 0, 0]); // 2^54 - 1
 
-pub const DECIMAL_RADIX: i32 = 10;
-pub const MPFR_T_PRECISION: u32 = 70;
+pub const MANTISSA_BITS_F64: i32 = 53;
+pub const F64_MAX_SAFE_INTEGER: f64 = 9007199254740991.0; // 2^53 - 1
+pub const F64_2P53: f64 = 9007199254740992.0; // 2^53
+pub const F64_2P54: f64 = 18014398509481984.0; // 2^54
+pub const F64_2P64: f64 = 18446744073709551616.0; // 2^64
+pub const F64_2P96: f64 = 79228162514264337593543950336.0; // 2^96
+pub const F64_2P128: f64 = 340282366920938463463374607431768211456.0; // 2^128
+pub const F64_2P192: f64 = 6277101735386680763835789423207666416102355444464034512896.0; // 2^192

--- a/src/amms/error.rs
+++ b/src/amms/error.rs
@@ -24,10 +24,10 @@ pub enum AMMError {
     BalancerError(#[from] BalancerError),
     #[error(transparent)]
     ERC4626VaultError(#[from] ERC4626VaultError),
-    #[error(transparent)]
-    ParseFloatError(#[from] rug::float::ParseFloatError),
     #[error("Unrecognized Event Signature {0}")]
     UnrecognizedEventSignature(FixedBytes<32>),
     #[error(transparent)]
     JoinError(#[from] tokio::task::JoinError),
+    #[error("Specified tokens are incompatible")]
+    IncompatibleToken,
 }

--- a/src/amms/factory.rs
+++ b/src/amms/factory.rs
@@ -1,8 +1,9 @@
-use super::{amm::Variant, uniswap_v2::UniswapV2Factory, uniswap_v3::UniswapV3Factory};
 use super::{
-    amm::{AutomatedMarketMaker, AMM},
+    amm::{AutomatedMarketMaker, Variant, AMM},
     balancer::BalancerFactory,
     error::AMMError,
+    uniswap_v2::UniswapV2Factory,
+    uniswap_v3::UniswapV3Factory,
 };
 use alloy::{
     eips::BlockId,
@@ -12,7 +13,6 @@ use alloy::{
     rpc::types::eth::Log,
     transports::Transport,
 };
-use eyre::Result;
 use serde::{Deserialize, Serialize};
 use std::{
     future::Future,

--- a/src/amms/float.rs
+++ b/src/amms/float.rs
@@ -1,25 +1,48 @@
 use alloy::primitives::U256;
-use rug::Float;
 
-use super::{
-    consts::{MPFR_T_PRECISION, U128_0X10000000000000000},
-    error::AMMError,
-};
+use super::consts::{F64_2P128, F64_2P192, F64_2P64};
 
-pub fn q64_to_float(num: u128) -> Result<f64, AMMError> {
-    let float_num = u128_to_float(num)?;
-    let divisor = u128_to_float(U128_0X10000000000000000)?;
-    Ok((float_num / divisor).to_f64())
+/// Converts an alloy U256 to f64 with nearest rounding
+pub fn u256_to_f64(num: U256) -> f64 {
+    let [l0, l1, l2, l3] = num.into_limbs();
+    let (l0f, l1f, l2f, l3f) = (l0 as f64, l1 as f64, l2 as f64, l3 as f64);
+    return l0f + l1f * F64_2P64 + l2f * F64_2P128 + l3f * F64_2P192;
 }
 
-pub fn u128_to_float(num: u128) -> Result<Float, AMMError> {
-    let value_string = num.to_string();
-    let parsed_value = Float::parse_radix(value_string, 10)?;
-    Ok(Float::with_val(MPFR_T_PRECISION, parsed_value))
-}
+#[cfg(test)]
+mod test {
+    use alloy::primitives::U256;
 
-pub fn u256_to_float(num: U256) -> Result<Float, AMMError> {
-    let value_string = num.to_string();
-    let parsed_value = Float::parse_radix(value_string, 10)?;
-    Ok(Float::with_val(MPFR_T_PRECISION, parsed_value))
+    use crate::amms::{consts::{
+        F64_2P54, F64_MAX_SAFE_INTEGER, MANTISSA_BITS_F64, U256_0X10000, U256_0X1FFFFFFFFFFFFF,
+        U256_0X3FFFFFFFFFFFFF, U256_1,
+    }, float::u256_to_f64};
+
+    #[test]
+    fn test_u256_to_f64_simple() {
+        assert_eq!(u256_to_f64(U256::ZERO), 0.0);
+        assert_eq!(u256_to_f64(U256_1), 1.0);
+        assert_eq!(u256_to_f64(U256_0X10000), 65536.0);
+    }
+
+    // Make sure that all bits in the input are not lost in the output
+    #[test]
+    fn test_u256_to_f64_all_bits() {
+        for i in 0..256 - MANTISSA_BITS_F64 {
+            let actual = u256_to_f64(U256_0X1FFFFFFFFFFFFF << i);
+            let expected = F64_MAX_SAFE_INTEGER * (2.0_f64.powi(i));
+            assert_eq!(actual, expected, "incorrect bits produced at shift {}", i);
+        }
+    }
+
+    // Ensures the correct rounding behavior on all positions (should round up)
+    #[test]
+    fn test_u256_to_f64_rounding() {
+        for i in 0..256 - (MANTISSA_BITS_F64 + 1) {
+            // Should round 2^54 - 1 up to 2^54 due to 53 bit mantissa
+            let actual = u256_to_f64(U256_0X3FFFFFFFFFFFFF << i);
+            let expected = F64_2P54 * (2.0_f64.powi(i));
+            assert_eq!(actual, expected, "incorrect rounding at shift {}", i);
+        }
+    }
 }

--- a/src/amms/mod.rs
+++ b/src/amms/mod.rs
@@ -76,6 +76,18 @@ impl From<Address> for Token {
     }
 }
 
+impl PartialEq<Address> for Token {
+    fn eq(&self, other: &Address) -> bool {
+        self.address() == *other
+    }
+}
+
+impl PartialEq<Token> for Address {
+    fn eq(&self, other: &Token) -> bool {
+        other == self
+    }
+}
+
 impl Hash for Token {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.address.hash(state);
@@ -132,4 +144,25 @@ where
         }
     }
     token_decimals
+}
+
+#[cfg(test)]
+mod test {
+    #[macro_export]
+    macro_rules! test_provider {
+        () => {{
+            let rpc_endpoint = ::std::env::var("ETHEREUM_PROVIDER")?;
+
+            let client = ::alloy::rpc::client::ClientBuilder::default()
+                .layer(::alloy_throttle::ThrottleLayer::new(250, None)?)
+                .layer(::alloy::transports::layers::RetryBackoffLayer::new(
+                    5, 200, 330,
+                ))
+                .http(rpc_endpoint.parse()?);
+
+            ::eyre::Ok(::std::sync::Arc::new(
+                ::alloy::providers::ProviderBuilder::new().on_client(client),
+            ))
+        }};
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
I noticed some inconsistencies with how pricing and fees work between different AMMs. This PR aims to unify them and solve a couple bugs I spotted.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- All fees (except balancer) are specified to `1e6` (Uniswap v3 standard) as base
- Fees are now included in costs
- Removed fixed point calculations and replaced with f64 directly
- Balancer fee must be u64 (bug fix)
- Consistent error type for unsupported tokens
- Uniswap v3 had the spot pricing backwards
- Fix #257 

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
