### PR TITLE
Fix: value filter filters out all AMMs due to misalignment with PoolType enum

### DIFF
--- a/contracts/test/WethValueInPoolsBatchRequest.t.sol
+++ b/contracts/test/WethValueInPoolsBatchRequest.t.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "../src/filters/WethValueInPoolsBatchRequest.sol";
+
+contract WethValueInPoolsBatchRequestTest is Test {
+    address uniswapV2Factory = 0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f;
+    address uniswapV3Factory = 0x1F98431c8aD98523631AE4a59f267346ea31F984;
+    address constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+    address constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+
+    function setUp() public {}
+
+    function test_WethValueInPoolsBatchRequest_validWeth() public {
+        WethValueInPools.PoolInfo[] memory testFixtureValidWeth = new WethValueInPools.PoolInfo[](3);
+        testFixtureValidWeth[0] = WethValueInPools.PoolInfo({
+            poolType: WethValueInPools.PoolType.Balancer,
+            poolAddress: 0x8a649274E4d777FFC6851F13d23A86BBFA2f2Fbf
+        });
+        testFixtureValidWeth[1] = WethValueInPools.PoolInfo({
+            poolType: WethValueInPools.PoolType.UniswapV2,
+            poolAddress: 0x397FF1542f962076d0BFE58eA045FfA2d347ACa0
+        });
+        testFixtureValidWeth[2] = WethValueInPools.PoolInfo({
+            poolType: WethValueInPools.PoolType.UniswapV3,
+            poolAddress: 0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640
+        });
+
+        bytes memory returnData = address(
+            new WethValueInPoolsBatchRequest(uniswapV2Factory, uniswapV3Factory, WETH, testFixtureValidWeth)
+        ).code;
+        WethValueInPools.PoolInfoReturn[] memory pools = abi.decode(returnData, (WethValueInPools.PoolInfoReturn[]));
+
+        assertEq(pools.length, 3);
+        // Check weth value > 0 and valid pool address and pool type
+        for (uint256 i = 0; i < pools.length; i++) {
+            assertGt(pools[i].wethValue, 0);
+            assertEq(uint8(pools[i].poolType), uint8(testFixtureValidWeth[i].poolType));
+            assertEq(pools[i].poolAddress, testFixtureValidWeth[i].poolAddress);
+        }
+    }
+
+    function test_WethValueInPoolsBatchRequest_validNoWeth() public {
+        WethValueInPools.PoolInfo[] memory testFixtureValidNoWeth = new WethValueInPools.PoolInfo[](3);
+        testFixtureValidNoWeth[0] = WethValueInPools.PoolInfo({
+            poolType: WethValueInPools.PoolType.Balancer,
+            poolAddress: 0xE5D1fAB0C5596ef846DCC0958d6D0b20E1Ec4498
+        });
+        testFixtureValidNoWeth[1] = WethValueInPools.PoolInfo({
+            poolType: WethValueInPools.PoolType.UniswapV2,
+            poolAddress: 0xAE461cA67B15dc8dc81CE7615e0320dA1A9aB8D5
+        });
+        testFixtureValidNoWeth[2] = WethValueInPools.PoolInfo({
+            poolType: WethValueInPools.PoolType.UniswapV3,
+            poolAddress: 0x6c6Bc977E13Df9b0de53b251522280BB72383700
+        });
+
+        bytes memory returnData = address(
+            new WethValueInPoolsBatchRequest(uniswapV2Factory, uniswapV3Factory, WETH, testFixtureValidNoWeth)
+        ).code;
+        WethValueInPools.PoolInfoReturn[] memory pools = abi.decode(returnData, (WethValueInPools.PoolInfoReturn[]));
+
+        assertEq(pools.length, 3);
+        // Check weth value > 0 and valid pool address and pool type
+        for (uint256 i = 0; i < pools.length; i++) {
+            assertGt(pools[i].wethValue, 0);
+            assertEq(uint8(pools[i].poolType), uint8(testFixtureValidNoWeth[i].poolType));
+            assertEq(pools[i].poolAddress, testFixtureValidNoWeth[i].poolAddress);
+        }
+    }
+
+    function test_WethValueInPoolsBatchRequest_invalid_no_revert() public {
+        WethValueInPools.PoolInfo[] memory testFixtureInvalid = new WethValueInPools.PoolInfo[](3);
+        testFixtureInvalid[0] = WethValueInPools.PoolInfo({
+            poolType: WethValueInPools.PoolType.Balancer,
+            poolAddress: 0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f
+        });
+        testFixtureInvalid[1] = WethValueInPools.PoolInfo({
+            poolType: WethValueInPools.PoolType.UniswapV2,
+            poolAddress: 0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f
+        });
+        testFixtureInvalid[2] = WethValueInPools.PoolInfo({
+            poolType: WethValueInPools.PoolType.UniswapV3,
+            poolAddress: 0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f
+        });
+
+        bytes memory returnData =
+            address(new WethValueInPoolsBatchRequest(uniswapV2Factory, uniswapV3Factory, WETH, testFixtureInvalid)).code;
+        WethValueInPools.PoolInfoReturn[] memory pools = abi.decode(returnData, (WethValueInPools.PoolInfoReturn[]));
+
+        assertEq(pools.length, 3);
+        // All weth values should be zero
+        for (uint256 i = 0; i < pools.length; i++) {
+            assertEq(pools[i].wethValue, 0);
+            assertEq(uint8(pools[i].poolType), uint8(testFixtureInvalid[i].poolType));
+            assertEq(pools[i].poolAddress, testFixtureInvalid[i].poolAddress);
+        }
+    }
+}

--- a/src/state_space/filters/value.rs
+++ b/src/state_space/filters/value.rs
@@ -91,11 +91,11 @@ where
             .map(|amm| {
                 let pool_address = amm.address();
                 let pool_type = match amm {
-                    AMM::UniswapV2Pool(_) => 0,
-                    AMM::UniswapV3Pool(_) => 1,
-                    // TODO: At the moment, filters are not compatible with vaults or balancer pools
+                    AMM::BalancerPool(_) => 0,
+                    AMM::UniswapV2Pool(_) => 1,
+                    AMM::UniswapV3Pool(_) => 2,
+                    // TODO: At the moment, filters are not compatible with vaults
                     AMM::ERC4626Vault(_) => todo!(),
-                    AMM::BalancerPool(_) => todo!(),
                 };
 
                 PoolInfo {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
When filtering by WETH value, all AMMs are filtered out.
This happens because the filter function provides the wrong PoolType value to the batch contract and causes the contract to return a WETH value of 0 for all pools.

There is a misalignment between:
```
enum PoolType {
        Balancer,
        UniswapV2,
        UniswapV3
}
```
and:
```
let pool_type = match amm {
    AMM::UniswapV2Pool(_) => 0,
    AMM::UniswapV3Pool(_) => 1,
    // TODO: At the moment, filters are not compatible with vaults or balancer pools
    AMM::ERC4626Vault(_) => todo!(),
    AMM::BalancerPool(_) => todo!(),
};
```

Bug report: https://github.com/darkforestry/amms-rs/issues/271

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Align pool_type in the state space value filter with poolType enum in the contract.
Balancer was enabled for this filter because it's supported in the contract by `function handleBalancerPool(address pool) internal returns (uint256)`.
A test for the batch contract was added to ensure that all types are supported.

## PR Checklist

- [+] Added Tests
- [-] Added Documentation
- [-] Breaking changes
