### PR TITLE
Bugfix: Add amm events to filter

### DIFF
--- a/src/state_space/mod.rs
+++ b/src/state_space/mod.rs
@@ -225,6 +225,12 @@ where
             }
         }
 
+        for amm in &self.amms {
+            for event in amm.sync_events() {
+                filter_set.insert(event)
+            }
+        }
+
         let block_filter = Filter::new().event_signature(FilterSet::from(
             filter_set.into_iter().collect::<Vec<FixedBytes<32>>>(),
         ));

--- a/src/state_space/mod.rs
+++ b/src/state_space/mod.rs
@@ -225,9 +225,13 @@ where
             }
         }
 
-        for amm in &self.amms {
-            for event in amm.sync_events() {
-                filter_set.insert(event)
+        for variant in amm_variants.keys() {
+            while let Some(amms) = amm_variants.get(variant) {
+                for amm in amms.iter() {
+                    for event in amm.sync_events() {
+                        filter_set.insert(event);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Subscribing to a StateSpaceManager caused errors on UniswapV3 Collect events due to incorrect filtering when only constructing with specified AMMs. This led to increased latency and crashes (if not caught properly). 

## Solution

Added AMM specific filters in the sync function.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
