### PR TITLE
Bugfix: No-Op AMM Filter Sync

### DIFF
--- a/src/state_space/mod.rs
+++ b/src/state_space/mod.rs
@@ -156,7 +156,6 @@ where
         let block_filter = Filter::new().event_signature(FilterSet::from(
             filter_set.into_iter().collect::<Vec<FixedBytes<32>>>(),
         ));
-        
         let mut amm_variants = HashMap::new();
         for amm in self.amms.into_iter() {
             amm_variants

--- a/src/state_space/mod.rs
+++ b/src/state_space/mod.rs
@@ -140,6 +140,23 @@ where
         let factories = self.factories.clone();
         let mut futures = FuturesUnordered::new();
 
+        let mut filter_set = HashSet::new();
+        for factory in &self.factories {
+            for event in factory.pool_events() {
+                filter_set.insert(event);
+            }
+        }
+
+        for amm in self.amms.iter() {
+            for event in amm.sync_events() {
+                filter_set.insert(event);
+            }
+        }
+
+        let block_filter = Filter::new().event_signature(FilterSet::from(
+            filter_set.into_iter().collect::<Vec<FixedBytes<32>>>(),
+        ));
+        
         let mut amm_variants = HashMap::new();
         for amm in self.amms.into_iter() {
             amm_variants
@@ -217,27 +234,6 @@ where
                 state_space.state.insert(address, amm);
             }
         }
-
-        let mut filter_set = HashSet::new();
-        for factory in &self.factories {
-            for event in factory.pool_events() {
-                filter_set.insert(event);
-            }
-        }
-
-        for variant in amm_variants.keys() {
-            while let Some(amms) = amm_variants.get(variant) {
-                for amm in amms.iter() {
-                    for event in amm.sync_events() {
-                        filter_set.insert(event);
-                    }
-                }
-            }
-        }
-
-        let block_filter = Filter::new().event_signature(FilterSet::from(
-            filter_set.into_iter().collect::<Vec<FixedBytes<32>>>(),
-        ));
 
         Ok(StateSpaceManager {
             latest_block: Arc::new(AtomicU64::new(self.latest_block)),

--- a/src/state_space/mod.rs
+++ b/src/state_space/mod.rs
@@ -225,9 +225,13 @@ where
             }
         }
 
-        for amm in &self.amms {
-            for event in amm.sync_events() {
-                filter_set.insert(event)
+        for variant in amm_variants.keys() {
+            while let Some(amms) = amm_variants.get(variant) {
+                for amm in amms.iter() {
+                    for event in amm.sync_events() {
+                        filter_set.insert(event);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

The current filters for pools are added *post draining* becoming a no-op.

## Solution

Create filters ahead of time. 

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
