### PR TITLE
chore(bench): add `simulate_swap` bench for ERC4626 vaults

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,3 +81,8 @@ harness = false
 [[bench]]
 name = "uniswap_v3"
 harness = false
+
+
+[[bench]]
+name = "erc_4626"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,6 @@ harness = false
 name = "uniswap_v3"
 harness = false
 
-
 [[bench]]
 name = "erc_4626"
 harness = false

--- a/benches/erc_4626.rs
+++ b/benches/erc_4626.rs
@@ -1,5 +1,5 @@
 use alloy::primitives::{address, U256};
-use amms::amms::{amm::AutomatedMarketMaker, uniswap_v2::UniswapV2Pool, Token};
+use amms::amms::{amm::AutomatedMarketMaker, erc_4626::ERC4626Vault};
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::Rng;
 
@@ -7,17 +7,19 @@ fn simulate_swap(c: &mut Criterion) {
     let token_a = address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
     let token_b = address!("fc0d6cf33e38bce7ca7d89c0e292274031b7157a");
 
-    let pool = UniswapV2Pool {
-        token_a: Token::new_with_decimals(token_a, 18),
-        token_b: Token::new_with_decimals(token_b, 18),
-        reserve_0: 20_000_000_u128,
-        reserve_1: 20_000_000_u128,
-        fee: 300,
-        ..Default::default()
+    let pool = ERC4626Vault {
+        vault_token: token_a,
+        vault_token_decimals: 18,
+        asset_token: token_b,
+        asset_token_decimals: 18,
+        vault_reserve: U256::from(20_000_000_u128),
+        asset_reserve: U256::from(20_000_000_u128),
+        deposit_fee: 300,
+        withdraw_fee: 300,
     };
 
     let mut rng = rand::thread_rng();
-    c.bench_function("uniswap_v2_simulate_swap", |b| {
+    c.bench_function("erc4626_simulate_swap", |b| {
         b.iter_with_setup(
             || U256::from(rng.gen_range(1_000..=1e24 as u128)),
             |amount| {
@@ -27,5 +29,5 @@ fn simulate_swap(c: &mut Criterion) {
     });
 }
 
-criterion_group!(uniswap_v2, simulate_swap);
-criterion_main!(uniswap_v2);
+criterion_group!(erc_4626, simulate_swap);
+criterion_main!(erc_4626);

--- a/benches/uniswap_v3.rs
+++ b/benches/uniswap_v3.rs
@@ -44,7 +44,5 @@ fn simulate_swap(c: &mut Criterion) {
     });
 }
 
-// TODO: bench syncing
-
 criterion_group!(uniswap_v3, simulate_swap);
 criterion_main!(uniswap_v3);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
ref #270 

## Solution
This PR introduces benchmarks for `ERC4626Vault::simulate_swap()`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
